### PR TITLE
Supports numbers configured that are bigger then Long limits

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigBitInteger.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBitInteger.java
@@ -1,0 +1,62 @@
+/**
+ *   Copyright (C) 2011-2012 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config.impl;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.math.BigInteger;
+
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.ConfigValueType;
+
+final class ConfigBigInteger extends ConfigNumber implements Serializable {
+
+    private static final long serialVersionUID = 2L;
+
+    final private BigInteger value;
+
+    ConfigBigInteger(ConfigOrigin origin, BigInteger value, String originalText) {
+        super(origin, originalText);
+        this.value = value;
+    }
+
+    @Override
+    public ConfigValueType valueType() {
+        return ConfigValueType.NUMBER;
+    }
+
+    @Override
+    public BigInteger unwrapped() {
+        return value;
+    }
+
+    @Override
+    String transformToString() {
+        String s = super.transformToString();
+        if (s == null)
+            return value.toString();
+        else
+            return s;
+    }
+
+    @Override
+    protected long longValue() {
+        return value.longValue();
+    }
+
+    @Override
+    protected double doubleValue() {
+        return value.doubleValue();
+    }
+
+    @Override
+    protected ConfigBigInteger newCopy(ConfigOrigin origin) {
+        return new ConfigBigInteger(origin, value, originalText);
+    }
+
+    // serialization all goes through SerializedConfigValue
+    private Object writeReplace() throws ObjectStreamException {
+        return new SerializedConfigValue(this);
+    }
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNumber.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNumber.java
@@ -5,6 +5,7 @@ package com.typesafe.config.impl;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.math.BigInteger;
 
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigOrigin;
@@ -91,6 +92,11 @@ abstract class ConfigNumber extends AbstractConfigValue implements Serializable 
             return new ConfigInt(origin, (int) number, originalText);
         else
             return new ConfigLong(origin, number, originalText);
+    }
+
+    static ConfigNumber newNumber(ConfigOrigin origin, BigInteger number,
+            String originalText) {
+            return new ConfigBigInteger(origin, number, originalText);
     }
 
     static ConfigNumber newNumber(ConfigOrigin origin, double number,

--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -5,6 +5,7 @@ package com.typesafe.config.impl;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -352,7 +353,11 @@ final class Tokenizer {
                     return Tokens.newDouble(lineOrigin, Double.parseDouble(s), s);
                 } else {
                     // this should throw if the integer is too large for Long
-                    return Tokens.newLong(lineOrigin, Long.parseLong(s), s);
+                    try {
+                      return Tokens.newLong(lineOrigin, Long.parseLong(s), s);
+                    } catch(NumberFormatException ex) {
+                      return Tokens.newBigInteger(lineOrigin, new BigInteger(s), s);
+                    }
                 }
             } catch (NumberFormatException e) {
                 throw problem(s, "Invalid number: '" + s + "'", true /* suggestQuotes */, e);

--- a/config/src/main/java/com/typesafe/config/impl/Tokens.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokens.java
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import com.typesafe.config.ConfigException;
@@ -415,6 +416,11 @@ final class Tokens {
     }
 
     static Token newLong(ConfigOrigin origin, long value, String originalText) {
+        return newValue(ConfigNumber.newNumber(origin, value,
+                originalText));
+    }
+
+    static Token newBigInteger(ConfigOrigin origin, BigInteger value, String originalText) {
         return newValue(ConfigNumber.newNumber(origin, value,
                 originalText));
     }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -6,6 +6,7 @@ package com.typesafe.config.impl
 import org.junit.Assert._
 import org.junit._
 import com.typesafe.config.ConfigValue
+import java.math.BigInteger
 import java.util.Collections
 import java.net.URL
 import scala.collection.JavaConverters._
@@ -85,16 +86,23 @@ class ConfigValueTest extends TestUtils {
 
     @Test
     def configIntAndLongEquality() {
+        val bigIntegerVal = bigIntegerValue(new BigInteger("42"))
         val longVal = longValue(42L)
         val intValue = longValue(42)
+        val bigIntegerValueB = bigIntegerValue(new BigInteger("43"))
         val longValueB = longValue(43L)
         val intValueB = longValue(43)
 
         checkEqualObjects(intValue, longVal)
         checkEqualObjects(intValueB, longValueB)
+        checkEqualObjects(bigIntegerVal, longVal)
+        checkEqualObjects(bigIntegerValueB, longValueB)
         checkNotEqualObjects(intValue, longValueB)
         checkNotEqualObjects(intValueB, longVal)
+        checkNotEqualObjects(bigIntegerVal, longValueB)
+        checkNotEqualObjects(bigIntegerValueB, longVal)
     }
+
 
     @Test
     def configDoubleEquality() {

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -548,6 +548,7 @@ abstract trait TestUtils {
     // make the test compare public API to itself.
     protected def intValue(i: Int) = new ConfigInt(fakeOrigin(), i, null)
     protected def longValue(l: Long) = new ConfigLong(fakeOrigin(), l, null)
+    protected def bigIntegerValue(bi: BigInteger) = new ConfigBigInteger(fakeOrigin(), bi, null)
     protected def boolValue(b: Boolean) = new ConfigBoolean(fakeOrigin(), b)
     protected def nullValue() = new ConfigNull(fakeOrigin())
     protected def stringValue(s: String) = new ConfigString(fakeOrigin(), s)

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -8,6 +8,7 @@ import org.junit._
 import com.typesafe.config.ConfigOrigin
 import java.io.Reader
 import java.io.StringReader
+import java.math.BigInteger
 import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigSyntax
@@ -591,6 +592,7 @@ abstract trait TestUtils {
     def tokenDouble(d: Double) = Tokens.newDouble(fakeOrigin(), d, null)
     def tokenInt(i: Int) = Tokens.newInt(fakeOrigin(), i, null)
     def tokenLong(l: Long) = Tokens.newLong(fakeOrigin(), l, null)
+    def tokenBigInteger(bi: BigInteger) = Tokens.newBigInteger(fakeOrigin(), bi, null)
     def tokenLine(line: Int) = Tokens.newLine(fakeOrigin.setLineNumber(line))
     def tokenComment(text: String) = Tokens.newComment(fakeOrigin(), text)
 

--- a/config/src/test/scala/com/typesafe/config/impl/TokenTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenTest.scala
@@ -3,6 +3,8 @@
  */
 package com.typesafe.config.impl
 
+import java.math.BigInteger
+
 import org.junit.Assert._
 import org.junit._
 
@@ -21,6 +23,10 @@ class TokenTest extends TestUtils {
         // long
         checkEqualObjects(tokenLong(42), tokenLong(42))
         checkNotEqualObjects(tokenLong(42), tokenLong(43))
+
+        // big integer
+        checkEqualObjects(tokenBigInteger(new BigInteger("42")), tokenBigInteger(new BigInteger("42")))
+        checkNotEqualObjects(tokenBigInteger(new BigInteger("42")), tokenBigInteger(new BigInteger("43")))
 
         // int and long mixed
         checkEqualObjects(tokenInt(42), tokenLong(42))


### PR DESCRIPTION
Will create a BigInteger if the number parsed from the config goes outside the limits of the long type.   I'm catching the NumberFormatException, ideally a regex check would probably be more performant but I'm not sure the exact regex Java would be using parsing the int to throw the exception.  By using the NumberFormatException I'm guaranteeing I'm conforming to java's spec of what is a long.

Also, I might be missing a few test cases, I added what I could see needed checking.
