### PR TITLE
Fix ConcurrentModificationException that occurs when system properties are being modified during a call to ConfigImpl#loadSystemProperties

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import com.typesafe.config.Config;
@@ -289,8 +290,18 @@ public class ConfigImpl {
         }
     }
 
+    private static Properties getSystemProperties() {
+        // Avoid ConcurrentModificationException due to parallel setting of system properties by copying properties
+        final Properties systemProperties = System.getProperties();
+        final Properties systemPropertiesCopy = new Properties();
+        synchronized (systemProperties) {
+            systemPropertiesCopy.putAll(systemProperties);
+        }
+        return systemPropertiesCopy;
+    }
+
     private static AbstractConfigObject loadSystemProperties() {
-        return (AbstractConfigObject) Parseable.newProperties(System.getProperties(),
+        return (AbstractConfigObject) Parseable.newProperties(getSystemProperties(),
                 ConfigParseOptions.defaults().setOriginDescription("system properties")).parse();
     }
 


### PR DESCRIPTION
Occasionally, I get a ConcurrentModificationException at application startup:

``` java
Caused by: java.lang.ExceptionInInitializerError: null
    at com.typesafe.config.impl.ConfigImpl.systemPropertiesAsConfigObject(ConfigImpl.java:304)
    at com.typesafe.config.impl.ConfigImpl.systemPropertiesAsConfig(ConfigImpl.java:312)
    at com.typesafe.config.impl.ConfigImpl$LoaderCache.getOrElseUpdate(ConfigImpl.java:48)
    at com.typesafe.config.impl.ConfigImpl.computeCachedConfig(ConfigImpl.java:85)
    at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:278)
    ... 26 common frames omitted
Caused by: java.util.ConcurrentModificationException: null
    at java.util.Hashtable$Enumerator.next(Hashtable.java:1048)
    at com.typesafe.config.impl.PropertiesParser.fromProperties(PropertiesParser.java:60)
    at com.typesafe.config.impl.Parseable$ParseableProperties.rawParseValue(Parseable.java:655)
    at com.typesafe.config.impl.Parseable$ParseableProperties.rawParseValue(Parseable.java:637)
    at com.typesafe.config.impl.Parseable.parseValue(Parseable.java:171)
    at com.typesafe.config.impl.Parseable.parseValue(Parseable.java:165)
    at com.typesafe.config.impl.Parseable.parse(Parseable.java:204)
    at com.typesafe.config.impl.ConfigImpl.loadSystemProperties(ConfigImpl.java:293)
    at com.typesafe.config.impl.ConfigImpl.access$000(ConfigImpl.java:26)
    at com.typesafe.config.impl.ConfigImpl$SystemPropertiesHolder.<clinit>(ConfigImpl.java:299)
    ... 35 common frames omitted
```

After this is thrown, any further attempts to use `ConfigImpl` result in:

``` java
Caused by: java.lang.NoClassDefFoundError: Could not initialize class com.typesafe.config.impl.ConfigImpl$SystemPropertiesHolder
    at com.typesafe.config.impl.ConfigImpl.systemPropertiesAsConfigObject(ConfigImpl.java:304)
    at com.typesafe.config.impl.ConfigImpl.systemPropertiesAsConfig(ConfigImpl.java:312)
    at com.typesafe.config.impl.ConfigImpl$LoaderCache.getOrElseUpdate(ConfigImpl.java:48)
    at com.typesafe.config.impl.ConfigImpl.computeCachedConfig(ConfigImpl.java:85)
    at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:278)
```

This patch fixes this issue by copying the system properties in a synchronized block and then using the copy in the call to `Parseable#parse`.
