### PR TITLE
#55 Parse String[] args commandline parameter

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -522,6 +522,15 @@ public final class ConfigFactory {
     public static Config parseProperties(Properties properties) {
         return parseProperties(properties, ConfigParseOptions.defaults());
     }
+    
+    public static Config parseArray(String[] args,
+            ConfigParseOptions options) {
+        return Parseable.newArray(args, options).parse().toConfig();
+    }
+    
+    public static Config parseArray(String[] args) {
+        return parseArray(args,ConfigParseOptions.defaults());
+    }
 
     public static Config parseReader(Reader reader, ConfigParseOptions options) {
         return Parseable.newReader(reader, options).parse().toConfig();

--- a/config/src/main/java/com/typesafe/config/impl/ArrayParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ArrayParser.java
@@ -1,0 +1,64 @@
+/**
+ *   Copyright (C) 2011 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config.impl;
+
+import java.util.Properties;
+
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigOrigin;
+
+final class ArrayParser {
+
+    static AbstractConfigObject fromArray(ConfigOrigin origin, String[] args) {
+        Properties props = new Properties();
+        int i = 0;
+        while (i < args.length) {
+            String key = args[i];
+
+            // Check parameter correctness
+            if (isParameter(key)) {
+                key = key.substring(1, key.length());
+            } else {
+                throw new ConfigException.Parse(origin, "Parameter " + key + " must start with '-'");
+            }
+
+            // Check if last parameter is a boolean parameter
+            if ((i + 1) == args.length) {
+                props.setProperty(key, Boolean.TRUE.toString());
+                break;
+            }
+
+            String value = args[i + 1];
+            // Check if boolean parameter
+            if (isParameter(value)) {
+                value = Boolean.TRUE.toString();
+                i -= 1;
+            }
+
+            props.setProperty(key, value);
+            // next parameter pair
+            i += 2;
+        }
+
+        // check if last parameter was skipped
+        if ((i - 1) == args.length) {
+            String key = args[i - 2];
+
+            // Check parameter correctness
+            if (isParameter(key)) {
+                key = key.substring(1, key.length());
+            } else {
+                throw new ConfigException.Parse(origin, "Parameter " + key + " must start with '-'");
+            }
+            props.setProperty(key, Boolean.TRUE.toString());
+        }
+
+        return PropertiesParser.fromProperties(origin, props);
+    }
+
+    static boolean isParameter(String key) {
+        return key.startsWith("-");
+    }
+
+}

--- a/config/src/main/java/com/typesafe/config/impl/Parseable.java
+++ b/config/src/main/java/com/typesafe/config/impl/Parseable.java
@@ -18,6 +18,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -673,5 +674,47 @@ public abstract class Parseable implements ConfigParseable {
 
     public static Parseable newProperties(Properties properties, ConfigParseOptions options) {
         return new ParseableProperties(properties, options);
+    }
+
+    private final static class ParseableArray extends Parseable {
+
+        final private String[] args;
+
+        public ParseableArray(String[] args, ConfigParseOptions options) {
+            this.args = args;
+            postConstruct(options);
+        }
+
+        @Override
+        protected Reader reader() throws IOException {
+            throw new ConfigException.BugOrBroken("reader() should not be called on array (String[] args)");
+        }
+
+        @Override
+        protected AbstractConfigObject rawParseValue(ConfigOrigin origin, ConfigParseOptions finalOptions) {
+            if (ConfigImpl.traceLoadsEnabled()) {
+                trace("Loading config from properties " + Arrays.toString(args));
+            }
+            return ArrayParser.fromArray(origin, args);
+        }
+
+        @Override
+        ConfigSyntax guessSyntax() {
+            return ConfigSyntax.PROPERTIES;
+        }
+
+        @Override
+        protected ConfigOrigin createOrigin() {
+            return SimpleConfigOrigin.newSimple("array");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(" + args.length + " array items)";
+        }
+    }
+
+    public static Parseable newArray(String[] args, ConfigParseOptions options) {
+        return new ParseableArray(args, options);
     }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ArrayTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ArrayTest.scala
@@ -1,0 +1,44 @@
+/**
+ *   Copyright (C) 2011 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config.impl
+
+import org.junit.Assert._
+import org.junit._
+import java.util.Properties
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigParseOptions
+import com.typesafe.config.ConfigFactory
+
+class ArrayTest extends TestUtils {
+
+  @Test
+  def booleanOption() {
+    val conf1 = ConfigFactory.parseArray(Array("-debug"))
+    assertEquals(conf1.getBoolean("debug"), true)
+
+    val conf2 = ConfigFactory.parseArray(Array("-debug", "-foo"))
+    assertEquals(conf2.getBoolean("debug"), true)
+    assertEquals(conf2.getBoolean("foo"), true)
+
+    val conf3 = ConfigFactory.parseArray(Array("-debug", "-bar", "false", "-foo"))
+    assertEquals(conf3.getBoolean("debug"), true)
+    assertEquals(conf3.getBoolean("foo"), true)
+    assertEquals(conf3.getBoolean("bar"), false)
+  }
+
+  @Test
+  def mixedArguments() {
+    val conf = ConfigFactory.parseArray(Array("-foo", "bar", "-debug", "-min", "0.123"))
+    assertEquals(conf.getString("foo"), "bar")
+    assertEquals(conf.getBoolean("debug"), true)
+    assertEquals(conf.getDouble("min"), 0.123, 0.0)
+  }
+
+  @Test
+  def mixedArgumentsWithPath() {
+    val conf = ConfigFactory.parseArray(Array("-foo.bar", "1.0", "-dev.debug"))
+    assertEquals(conf.getConfig("foo").getDouble("bar"), 1.0, 0.0)
+    assertEquals(conf.getBoolean("dev.debug"), true)
+  }
+}


### PR DESCRIPTION
This is a first implementation. It reuses the _parseProperties_ implementation. The following things are possible
### Single boolean parameters

``` scala
val conf = ConfigFactory.parseArray(Array("-debug"))
conf.getBoolean("debug") // true: boolean
```
### Multiple parameters

``` scala
val conf = ConfigFactory.parseArray(Array("-foo", "bar", "-debug"))
conf.getString("foo") // bar: String
conf.getBoolean("debug") // true: boolean
```
