### PR TITLE
Compile with debug symbols

### DIFF
--- a/config/build.sbt
+++ b/config/build.sbt
@@ -29,4 +29,4 @@ seq(jacoco.settings : _*)
 
 javacOptions in (Compile,doc) ++= Seq("-exclude", "com.typesafe.config.impl")
 
-javacOptions in (Compile,compile) ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions in (Compile,compile) ++= Seq("-source", "1.6", "-target", "1.6", "-g")


### PR DESCRIPTION
Typesafe config is not compiled with debug symbols.  This makes debugging hard.
