### PR TITLE
Allow unquoted strings consisting entirely of number chars

### DIFF
--- a/HOCON.md
+++ b/HOCON.md
@@ -441,6 +441,7 @@ number-to-string library function).
    be a two-element path with `foo10` and `0` as the elements.
  - `foo"10.0"` is an unquoted then a quoted string which are
    concatenated, so this is a single-element path.
+ - `1.2.3` is the three-element path with `1`,`2`,`3`
 
 Unlike value concatenations, path expressions are _always_
 converted to a string, even if they are just a single value.

--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -355,7 +355,15 @@ final class Tokenizer {
                     return Tokens.newLong(lineOrigin, Long.parseLong(s), s);
                 }
             } catch (NumberFormatException e) {
-                throw problem(s, "Invalid number: '" + s + "'", true /* suggestQuotes */, e);
+                // not a number after all, see if it's an unquoted string.
+                for (char u : s.toCharArray()) {
+                    if (notInUnquotedText.indexOf(u) >= 0)
+                        throw problem(asString(u), "Reserved character '" + asString(u)
+                                      + "' is not allowed outside quotes", true /* suggestQuotes */);
+                }
+                // no evil chars so we just decide this was a string and
+                // not a number.
+                return Tokens.newUnquotedText(lineOrigin, s);
             }
         }
 

--- a/config/src/test/scala/com/typesafe/config/impl/PathTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PathTest.scala
@@ -67,6 +67,9 @@ class PathTest extends TestUtils {
             RenderTest("\" foo \"", path(" foo ")),
             // trailing space only
             RenderTest("\"foo \"", path("foo ")))
+            // numbers with decimal points
+            RenderTest("1.2", path("1", "2"))
+            RenderTest("1.2.3.4", path("1", "2", "3", "4"))
 
         for (t <- tests) {
             assertEquals(t.expected, t.path.render())


### PR DESCRIPTION
Previously, a string which was an invalid number (such as
"1.0.0" or "1e3e3") but consisted entirely of chars allowed
in numbers would be an error and require quoting. Now, we
allow such strings to be unquoted.

This should fix issue #115 
