### PR TITLE
Don't run tests in parallel

### DIFF
--- a/config/build.sbt
+++ b/config/build.sbt
@@ -35,3 +35,7 @@ seq(jacoco.settings : _*)
 javacOptions in (Compile,doc) ++= Seq("-exclude", "com.typesafe.config.impl")
 
 javacOptions in (Compile,compile) ++= Seq("-source", "1.6", "-target", "1.6", "-g")
+
+// because we test some global state such as singleton caches,
+// we have to run tests in serial.
+parallelExecution in Test := false


### PR DESCRIPTION
Since some of them test global state, such as the reference config cache.

Fixes #9 which was just broken tests not a real bug.
