### PR TITLE
Require config.file/resource/url to exist regardless of parse options

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -219,21 +219,22 @@ public final class ConfigFactory {
                     + "', config.url='" + url + "', config.resource='" + resource
                     + "'; don't know which one to use!");
         } else {
+            // the override file/url/resource MUST be present or it's an error
+            ConfigParseOptions overrideOptions = parseOptions.setAllowMissing(false);
             if (resource != null) {
                 if (resource.startsWith("/"))
                     resource = resource.substring(1);
                 // this deliberately does not parseResourcesAnySyntax; if
                 // people want that they can use an include statement.
-                return load(loader, parseResources(loader, resource, parseOptions), resolveOptions);
+                Config parsedResources = parseResources(loader, resource, overrideOptions);
+                return load(loader, parsedResources, resolveOptions);
             } else if (file != null) {
-                return load(
-                        loader,
-                        parseFile(new File(file), parseOptions), resolveOptions);
+                Config parsedFile = parseFile(new File(file), overrideOptions);
+                return load(loader, parsedFile, resolveOptions);
             } else {
                 try {
-                    return load(
-                            loader,
-                            parseURL(new URL(url), parseOptions), resolveOptions);
+                    Config parsedURL = parseURL(new URL(url), overrideOptions);
+                    return load(loader, parsedURL, resolveOptions);
                 } catch (MalformedURLException e) {
                     throw new ConfigException.Generic("Bad URL in config.url system property: '"
                             + url + "': " + e.getMessage(), e);

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -828,20 +828,48 @@ class PublicApiTest extends TestUtils {
     }
 
     @Test
-    def missingConfFails() {
+    def missingOverrideResourceFails() {
+        assertEquals("config.file is not set", null, System.getProperty("config.file"))
         val old = System.getProperty("config.resource")
-        System.setProperty("config.resource", "donotexists.conf")
-        intercept[ConfigException.IO] {
-            ConfigFactory.load(ConfigParseOptions.defaults().setAllowMissing(false))
+        try {
+            System.setProperty("config.resource", "donotexists.conf")
+            intercept[ConfigException.IO] {
+                ConfigFactory.load()
+            }
+        } finally {
+            // cleanup properties
+            Option(old).map { v =>
+                System.setProperty("config.resource", v)
+                v
+            }.orElse {
+                System.clearProperty("config.resource")
+                None
+            }
+            assertEquals("config.resource restored", old, System.getProperty("config.resource"))
+            ConfigImpl.reloadSystemPropertiesConfig()
         }
+    }
 
-        // cleanup properties
-        Option(old).map { v =>
-            System.setProperty("config.resource", v)
-            v
-        }.orElse {
-            System.clearProperty("config.resource")
-            None
+    @Test
+    def missingOverrideFileFails() {
+        assertEquals("config.resource is not set", null, System.getProperty("config.resource"))
+        val old = System.getProperty("config.file")
+        try {
+            System.setProperty("config.file", "donotexists.conf")
+            intercept[ConfigException.IO] {
+                ConfigFactory.load()
+            }
+        } finally {
+            // cleanup properties
+            Option(old).map { v =>
+                System.setProperty("config.file", v)
+                v
+            }.orElse {
+                System.clearProperty("config.file")
+                None
+            }
+            assertEquals("config.file restored", old, System.getProperty("config.file"))
+            ConfigImpl.reloadSystemPropertiesConfig()
         }
     }
 


### PR DESCRIPTION
These are overriding what was set programmatically, so even if
the app wants to allow the config file to be missing normally,
since these were manually specified they should have to exist.
People get confused when they set a nonexistent file and it
silently doesn't work.

Fixes #97
