### PR TITLE
Added ConfigRenderOptions entry for value sorting in objects.

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigRenderOptions.java
+++ b/config/src/main/java/com/typesafe/config/ConfigRenderOptions.java
@@ -21,15 +21,13 @@ public final class ConfigRenderOptions {
     private final boolean comments;
     private final boolean formatted;
     private final boolean json;
-    private final boolean sortObjects;
 
     private ConfigRenderOptions(boolean originComments, boolean comments, boolean formatted,
-            boolean json, boolean sortObjects) {
+            boolean json) {
         this.originComments = originComments;
         this.comments = comments;
         this.formatted = formatted;
         this.json = json;
-        this.sortObjects = sortObjects;
     }
 
     /**
@@ -40,7 +38,7 @@ public final class ConfigRenderOptions {
      * @return the default render options
      */
     public static ConfigRenderOptions defaults() {
-        return new ConfigRenderOptions(true, true, true, true, true);
+        return new ConfigRenderOptions(true, true, true, true);
     }
 
     /**
@@ -50,7 +48,7 @@ public final class ConfigRenderOptions {
      * @return the concise render options
      */
     public static ConfigRenderOptions concise() {
-        return new ConfigRenderOptions(false, false, false, true, false);
+        return new ConfigRenderOptions(false, false, false, true);
     }
 
     /**
@@ -66,7 +64,7 @@ public final class ConfigRenderOptions {
         if (value == comments)
             return this;
         else
-            return new ConfigRenderOptions(originComments, value, formatted, json, sortObjects);
+            return new ConfigRenderOptions(originComments, value, formatted, json);
     }
 
     /**
@@ -99,7 +97,7 @@ public final class ConfigRenderOptions {
         if (value == originComments)
             return this;
         else
-            return new ConfigRenderOptions(value, comments, formatted, json, sortObjects);
+            return new ConfigRenderOptions(value, comments, formatted, json);
     }
 
     /**
@@ -124,7 +122,7 @@ public final class ConfigRenderOptions {
         if (value == formatted)
             return this;
         else
-            return new ConfigRenderOptions(originComments, comments, value, json, sortObjects);
+            return new ConfigRenderOptions(originComments, comments, value, json);
     }
 
     /**
@@ -152,7 +150,7 @@ public final class ConfigRenderOptions {
         if (value == json)
             return this;
         else
-            return new ConfigRenderOptions(originComments, comments, formatted, value, sortObjects);
+            return new ConfigRenderOptions(originComments, comments, formatted, value);
     }
 
     /**
@@ -163,32 +161,6 @@ public final class ConfigRenderOptions {
      */
     public boolean getJson() {
         return json;
-    }
-
-    /**
-     * Returns options with object sorting enabled. Object sorting means that
-     * child values of object nodes will be processed in order of their key
-     * values, i.e. the keys will be sorted before being iterated over.
-     *
-     * @param value
-     *            true to sort object values in the render
-     * @return options with the requested setting for object sorting
-     */
-    public ConfigRenderOptions setSortObjects(boolean value) {
-        if (value == sortObjects)
-            return this;
-        else
-            return new ConfigRenderOptions(originComments, comments, formatted, json, value);
-    }
-
-    /**
-     * Returns whether the options enable object key sorting. This method is
-     * mostly used by the config lib internally, not by applications.
-     *
-     * @return true if objects should be sorted by their keys.
-     */
-    public boolean getSortObjects() {
-        return sortObjects;
     }
 
     @Override
@@ -202,8 +174,6 @@ public final class ConfigRenderOptions {
             sb.append("formatted,");
         if (json)
             sb.append("json,");
-        if (sortObjects)
-            sb.append("sortObjects,");
         if (sb.charAt(sb.length() - 1) == ',')
             sb.setLength(sb.length() - 1);
         sb.append(")");

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -7,6 +7,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -382,14 +383,8 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             }
 
             int separatorCount = 0;
-            Iterable<String> keys;
-            if (options.getSortObjects()) {
-                List<String> list = new ArrayList<String>(keySet());
-                Collections.sort(list);
-                keys = list;
-            } else {
-                keys = keySet();
-            }
+            String[] keys = keySet().toArray(new String[size()]);
+            Arrays.sort(keys);
             for (String k : keys) {
                 AbstractConfigValue v;
                 v = value.get(k);


### PR DESCRIPTION
When enabled, this gives a more deterministic output by sorting the keys of config objects before writing them (handled in `SimpleConfigObject`, not sure if/how this might apply in `ConfigDelayedMerge`?).

This is very useful in case the generated config file is intended to be hand-edited, since settings will always be at the same place in the config.
