### PR TITLE
Parse env variables so that they don't all end up as strings

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -332,15 +332,12 @@ public class ConfigImpl {
 
     private static AbstractConfigObject loadEnvVariables() {
         Map<String, String> env = System.getenv();
-        Map<String, AbstractConfigValue> m = new HashMap<String, AbstractConfigValue>();
+        Properties properties = new Properties();
         for (Map.Entry<String, String> entry : env.entrySet()) {
-            String key = entry.getKey();
-            m.put(key,
-                    new ConfigString(SimpleConfigOrigin.newSimple("env var " + key), entry
-                            .getValue()));
+            properties.put(entry.getKey(), entry.getValue());
         }
-        return new SimpleConfigObject(SimpleConfigOrigin.newSimple("env variables"),
-                m, ResolveStatus.RESOLVED, false /* ignoresFallbacks */);
+        return (AbstractConfigObject) Parseable.newProperties(properties,
+                ConfigParseOptions.defaults().setOriginDescription("env variables")).parse();
     }
 
     private static class EnvVariablesHolder {


### PR DESCRIPTION
When a key resolution fallbacks to an existing environment variable, the type of that key is always `String`, although it might be an `int` and would be parsed as such if the exact same content was injected directly in the config or via a system property.

This makes sure that the same code path is hit for environment variables and system properties, effectively making environment variables first class citizens when it comes to setting values. 

I could not come up with a generic way to test it without doing some refactoring around the call to `System.getEnv()`, since AFAIK, it's impossible to set an environment variable at runtime and there is no canonical numerical environment variable we could use. An (uncommited) adhoc unit test passed locally, where a `GNOME_KEYRING_PID=2055` was set.
