### PR TITLE
Add ability to set comments

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -885,7 +885,7 @@ public final class ConfigFactory {
      */
     public static Config parseMap(Map<String, ? extends Object> values,
             String originDescription) {
-        return ConfigImpl.fromPathMap(values, originDescription).toConfig();
+        return ConfigImpl.fromPathMap(values, originDescription, null).toConfig();
     }
 
     /**

--- a/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
@@ -16,20 +16,6 @@ public final class ConfigValueFactory {
     private ConfigValueFactory() {
     }
 
-    public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
-        return ConfigImpl.fromAnyRef(object, originDescription, comments);
-    }
-
-    public static ConfigObject fromMap(Map<String, ? extends Object> values,
-            String originDescription, String[] comments) {
-        return (ConfigObject) fromAnyRef(values, originDescription, comments);
-    }
-
-    public static ConfigList fromIterable(Iterable<? extends Object> values,
-            String originDescription, String[] comments) {
-        return (ConfigList) fromAnyRef(values, originDescription, comments);
-    }
-    
     /**
      * Creates a {@link ConfigValue} from a plain Java boxed value, which may be
      * a <code>Boolean</code>, <code>Number</code>, <code>String</code>,
@@ -58,6 +44,11 @@ public final class ConfigValueFactory {
      * where problematic values are coming from.
      * 
      * <p>
+     * The comments will be used on the origin() field on the ConfigValue
+     * created. In case of ConfigObject or ConfigList, the values in them will
+     * not contain any comments.
+     * 
+     * <p>
      * Supplying the result of ConfigValue.unwrapped() to this function is
      * guaranteed to work and should give you back a ConfigValue that matches
      * the one you unwrapped. The re-wrapped ConfigValue will lose some
@@ -76,8 +67,8 @@ public final class ConfigValueFactory {
      *            name of origin file or brief description of what the value is
      * @return a new value
      */
-    public static ConfigValue fromAnyRef(Object object, String originDescription) {
-        return ConfigImpl.fromAnyRef(object, originDescription, null);
+    public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
+        return ConfigImpl.fromAnyRef(object, originDescription, comments);
     }
 
     /**
@@ -104,8 +95,8 @@ public final class ConfigValueFactory {
      * @return a new {@link ConfigObject} value
      */
     public static ConfigObject fromMap(Map<String, ? extends Object> values,
-            String originDescription) {
-        return (ConfigObject) fromAnyRef(values, originDescription);
+            String originDescription, String[] comments) {
+        return (ConfigObject) fromAnyRef(values, originDescription, comments);
     }
 
     /**
@@ -116,6 +107,45 @@ public final class ConfigValueFactory {
      * @param values
      * @param originDescription
      * @return a new {@link ConfigList} value
+     */
+    public static ConfigList fromIterable(Iterable<? extends Object> values,
+            String originDescription, String[] comments) {
+        return (ConfigList) fromAnyRef(values, originDescription, comments);
+    }
+
+    /**
+     * See the other overload {@link #fromAnyRef(Object,String,String[])} for details,
+     * this one uses empty comment.
+     *
+     * @param object
+     * @return a new {@link ConfigValue}
+     */
+    public static ConfigValue fromAnyRef(Object object, String originDescription) {
+        return ConfigImpl.fromAnyRef(object, originDescription, null);
+    }
+
+    /**
+     * See the other overload {@link #fromMap(Map,String,String[])} for details,
+     * this one uses empty comment.
+     *
+     * <p>
+     * See also {@link ConfigFactory#parseMap(Map)} which interprets the keys in
+     * the map as path expressions.
+     *
+     * @param values
+     * @return a new {@link ConfigObject}
+     */
+    public static ConfigObject fromMap(Map<String, ? extends Object> values,
+            String originDescription) {
+        return (ConfigObject) fromAnyRef(values, originDescription);
+    }
+
+    /**
+     * See the other overload of {@link #fromIterable(Iterable, String, String[])} for
+     * details, this one uses empty comment.
+     *
+     * @param values
+     * @return a new {@link ConfigList}
      */
     public static ConfigList fromIterable(Iterable<? extends Object> values,
             String originDescription) {

--- a/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
@@ -65,6 +65,8 @@ public final class ConfigValueFactory {
      *            object to convert to ConfigValue
      * @param originDescription
      *            name of origin file or brief description of what the value is
+     * @param comments
+     *            comments on this ConfigValue used when it's rendered
      * @return a new value
      */
     public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
@@ -92,6 +94,7 @@ public final class ConfigValueFactory {
      * 
      * @param values
      * @param originDescription
+     * @param comments
      * @return a new {@link ConfigObject} value
      */
     public static ConfigObject fromMap(Map<String, ? extends Object> values,
@@ -106,6 +109,7 @@ public final class ConfigValueFactory {
      * 
      * @param values
      * @param originDescription
+     * @param comments
      * @return a new {@link ConfigList} value
      */
     public static ConfigList fromIterable(Iterable<? extends Object> values,
@@ -118,6 +122,7 @@ public final class ConfigValueFactory {
      * this one uses empty comment.
      *
      * @param object
+     * @param originDescription
      * @return a new {@link ConfigValue}
      */
     public static ConfigValue fromAnyRef(Object object, String originDescription) {
@@ -133,6 +138,7 @@ public final class ConfigValueFactory {
      * the map as path expressions.
      *
      * @param values
+     * @param originDescription
      * @return a new {@link ConfigObject}
      */
     public static ConfigObject fromMap(Map<String, ? extends Object> values,
@@ -145,6 +151,7 @@ public final class ConfigValueFactory {
      * details, this one uses empty comment.
      *
      * @param values
+     * @param originDescription
      * @return a new {@link ConfigList}
      */
     public static ConfigList fromIterable(Iterable<? extends Object> values,

--- a/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
@@ -16,6 +16,20 @@ public final class ConfigValueFactory {
     private ConfigValueFactory() {
     }
 
+    public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
+        return ConfigImpl.fromAnyRef(object, originDescription, comments);
+    }
+
+    public static ConfigObject fromMap(Map<String, ? extends Object> values,
+            String originDescription, String[] comments) {
+        return (ConfigObject) fromAnyRef(values, originDescription, comments);
+    }
+
+    public static ConfigList fromIterable(Iterable<? extends Object> values,
+            String originDescription, String[] comments) {
+        return (ConfigList) fromAnyRef(values, originDescription, comments);
+    }
+    
     /**
      * Creates a {@link ConfigValue} from a plain Java boxed value, which may be
      * a <code>Boolean</code>, <code>Number</code>, <code>String</code>,
@@ -63,7 +77,7 @@ public final class ConfigValueFactory {
      * @return a new value
      */
     public static ConfigValue fromAnyRef(Object object, String originDescription) {
-        return ConfigImpl.fromAnyRef(object, originDescription);
+        return ConfigImpl.fromAnyRef(object, originDescription, null);
     }
 
     /**

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -202,7 +202,8 @@ public class ConfigImpl {
     /** For use ONLY by library internals, DO NOT TOUCH not guaranteed ABI */
     public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
         ConfigOrigin valueOrigin = valueOrigin(originDescription, comments);
-        ConfigOrigin origin = valueOrigin(originDescription);
+        ConfigOrigin origin = (object != null && (object instanceof Map || object instanceof Iterable)) ?
+        		valueOrigin(originDescription) : null;
         return fromAnyRef(object, valueOrigin, origin, FromMapMode.KEYS_ARE_KEYS);
     }
 
@@ -251,6 +252,12 @@ public class ConfigImpl {
             } else {
                 return ConfigNumber.newNumber(valueOrigin,
                         ((Number) object).doubleValue(), null);
+            }
+        } else if (object instanceof AbstractConfigValue) {
+            if (origin == null) {
+                return ((AbstractConfigValue) object).newCopy(valueOrigin);
+            } else {
+                return (AbstractConfigValue) object;
             }
         } else if (object instanceof Map) {
             if (((Map<?, ?>) object).isEmpty())

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -6,6 +6,7 @@ package com.typesafe.config.impl;
 import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -187,42 +188,54 @@ public class ConfigImpl {
         else
             return SimpleConfigOrigin.newSimple(originDescription);
     }
+    
+    private static ConfigOrigin valueOrigin(String originDescription, String[] comments) {
+    	if (originDescription == null && comments == null) 
+    		return defaultValueOrigin;
+    	if (comments == null)
+            return SimpleConfigOrigin.newSimple(originDescription);
+    	if (originDescription == null)
+    		return ((SimpleConfigOrigin) defaultValueOrigin).setComments(Arrays.asList(comments));
+    	return SimpleConfigOrigin.newSimple(originDescription).setComments(Arrays.asList(comments));
+    }
 
     /** For use ONLY by library internals, DO NOT TOUCH not guaranteed ABI */
-    public static ConfigValue fromAnyRef(Object object, String originDescription) {
+    public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
+        ConfigOrigin valueOrigin = valueOrigin(originDescription, comments);
         ConfigOrigin origin = valueOrigin(originDescription);
-        return fromAnyRef(object, origin, FromMapMode.KEYS_ARE_KEYS);
+        return fromAnyRef(object, valueOrigin, origin, FromMapMode.KEYS_ARE_KEYS);
     }
 
     /** For use ONLY by library internals, DO NOT TOUCH not guaranteed ABI */
     public static ConfigObject fromPathMap(
-            Map<String, ? extends Object> pathMap, String originDescription) {
+            Map<String, ? extends Object> pathMap, String originDescription, String[] comments) {
+        ConfigOrigin valueOrigin = valueOrigin(originDescription, comments);
         ConfigOrigin origin = valueOrigin(originDescription);
-        return (ConfigObject) fromAnyRef(pathMap, origin,
+        return (ConfigObject) fromAnyRef(pathMap, valueOrigin, origin,
                 FromMapMode.KEYS_ARE_PATHS);
     }
 
-    static AbstractConfigValue fromAnyRef(Object object, ConfigOrigin origin,
+    static AbstractConfigValue fromAnyRef(Object object, ConfigOrigin valueOrigin, ConfigOrigin origin,
             FromMapMode mapMode) {
-        if (origin == null)
+        if (valueOrigin == null)
             throw new ConfigException.BugOrBroken(
                     "origin not supposed to be null");
 
         if (object == null) {
-            if (origin != defaultValueOrigin)
-                return new ConfigNull(origin);
+            if (valueOrigin != defaultValueOrigin)
+                return new ConfigNull(valueOrigin);
             else
                 return defaultNullValue;
         } else if (object instanceof Boolean) {
-            if (origin != defaultValueOrigin) {
-                return new ConfigBoolean(origin, (Boolean) object);
+            if (valueOrigin != defaultValueOrigin) {
+                return new ConfigBoolean(valueOrigin, (Boolean) object);
             } else if ((Boolean) object) {
                 return defaultTrueValue;
             } else {
                 return defaultFalseValue;
             }
         } else if (object instanceof String) {
-            return new ConfigString(origin, (String) object);
+            return new ConfigString(valueOrigin, (String) object);
         } else if (object instanceof Number) {
             // here we always keep the same type that was passed to us,
             // rather than figuring out if a Long would fit in an Int
@@ -230,18 +243,18 @@ public class ConfigImpl {
             // not using ConfigNumber.newNumber() when we have a
             // Double, Integer, or Long.
             if (object instanceof Double) {
-                return new ConfigDouble(origin, (Double) object, null);
+                return new ConfigDouble(valueOrigin, (Double) object, null);
             } else if (object instanceof Integer) {
-                return new ConfigInt(origin, (Integer) object, null);
+                return new ConfigInt(valueOrigin, (Integer) object, null);
             } else if (object instanceof Long) {
-                return new ConfigLong(origin, (Long) object, null);
+                return new ConfigLong(valueOrigin, (Long) object, null);
             } else {
-                return ConfigNumber.newNumber(origin,
+                return ConfigNumber.newNumber(valueOrigin,
                         ((Number) object).doubleValue(), null);
             }
         } else if (object instanceof Map) {
             if (((Map<?, ?>) object).isEmpty())
-                return emptyObject(origin);
+                return emptyObject(valueOrigin);
 
             if (mapMode == FromMapMode.KEYS_ARE_KEYS) {
                 Map<String, AbstractConfigValue> values = new HashMap<String, AbstractConfigValue>();
@@ -252,26 +265,26 @@ public class ConfigImpl {
                                 "bug in method caller: not valid to create ConfigObject from map with non-String key: "
                                         + key);
                     AbstractConfigValue value = fromAnyRef(entry.getValue(),
-                            origin, mapMode);
+                    		origin, origin, mapMode);
                     values.put((String) key, value);
                 }
 
-                return new SimpleConfigObject(origin, values);
+                return new SimpleConfigObject(valueOrigin, values);
             } else {
-                return PropertiesParser.fromPathMap(origin, (Map<?, ?>) object);
+                return PropertiesParser.fromPathMap(valueOrigin, origin, (Map<?, ?>) object);
             }
         } else if (object instanceof Iterable) {
             Iterator<?> i = ((Iterable<?>) object).iterator();
             if (!i.hasNext())
-                return emptyList(origin);
+                return emptyList(valueOrigin);
 
             List<AbstractConfigValue> values = new ArrayList<AbstractConfigValue>();
             while (i.hasNext()) {
-                AbstractConfigValue v = fromAnyRef(i.next(), origin, mapMode);
+                AbstractConfigValue v = fromAnyRef(i.next(), origin, origin, mapMode);
                 values.add(v);
             }
 
-            return new SimpleConfigList(origin, values);
+            return new SimpleConfigList(valueOrigin, values);
         } else {
             throw new ConfigException.BugOrBroken(
                     "bug in method caller: not valid to create ConfigValue from: "

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -213,6 +213,8 @@ public class ConfigImpl {
             Map<String, ? extends Object> pathMap, String originDescription, String[] comments) {
         ConfigOrigin valueOrigin = valueOrigin(originDescription, comments);
         ConfigOrigin origin = valueOrigin(originDescription);
+        if (pathMap != null && pathMap instanceof ConfigValue)
+            pathMap = (Map<String, ? extends Object>) ((ConfigValue) pathMap).unwrapped();
         return (ConfigObject) fromAnyRef(pathMap, valueOrigin, origin,
                 FromMapMode.KEYS_ARE_PATHS);
     }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -202,8 +202,9 @@ public class ConfigImpl {
     /** For use ONLY by library internals, DO NOT TOUCH not guaranteed ABI */
     public static ConfigValue fromAnyRef(Object object, String originDescription, String[] comments) {
         ConfigOrigin valueOrigin = valueOrigin(originDescription, comments);
-        ConfigOrigin origin = (object != null && (object instanceof Map || object instanceof Iterable)) ?
-        		valueOrigin(originDescription) : null;
+        ConfigOrigin origin = valueOrigin(originDescription);
+        if (object != null && object instanceof ConfigValue)
+            object = ((ConfigValue) object).unwrapped();
         return fromAnyRef(object, valueOrigin, origin, FromMapMode.KEYS_ARE_KEYS);
     }
 
@@ -254,11 +255,7 @@ public class ConfigImpl {
                         ((Number) object).doubleValue(), null);
             }
         } else if (object instanceof AbstractConfigValue) {
-            if (origin == null) {
-                return ((AbstractConfigValue) object).newCopy(valueOrigin);
-            } else {
-                return (AbstractConfigValue) object;
-            }
+            return (AbstractConfigValue) object;
         } else if (object instanceof Map) {
             if (((Map<?, ?>) object).isEmpty())
                 return emptyObject(valueOrigin);

--- a/config/src/main/java/com/typesafe/config/impl/PropertiesParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/PropertiesParser.java
@@ -54,7 +54,7 @@ final class PropertiesParser {
         return path;
     }
 
-    static AbstractConfigObject fromProperties(ConfigOrigin origin,
+    static AbstractConfigObject fromProperties(ConfigOrigin valueOrigin, ConfigOrigin origin,
             Properties props) {
         Map<Path, Object> pathMap = new HashMap<Path, Object>();
         for (Map.Entry<Object, Object> entry : props.entrySet()) {
@@ -64,10 +64,15 @@ final class PropertiesParser {
                 pathMap.put(path, entry.getValue());
             }
         }
-        return fromPathMap(origin, pathMap, true /* from properties */);
+        return fromPathMap(valueOrigin, origin, pathMap, true /* from properties */);
+    }
+    
+    static AbstractConfigObject fromProperties(ConfigOrigin origin,
+            Properties props) {
+    	return fromProperties(origin, origin, props);
     }
 
-    static AbstractConfigObject fromPathMap(ConfigOrigin origin,
+    static AbstractConfigObject fromPathMap(ConfigOrigin valueOrigin, ConfigOrigin origin,
             Map<?, ?> pathExpressionMap) {
         Map<Path, Object> pathMap = new HashMap<Path, Object>();
         for (Map.Entry<?, ?> entry : pathExpressionMap.entrySet()) {
@@ -79,10 +84,10 @@ final class PropertiesParser {
             Path path = Path.newPath((String) keyObj);
             pathMap.put(path, entry.getValue());
         }
-        return fromPathMap(origin, pathMap, false /* from properties */);
+        return fromPathMap(valueOrigin, origin, pathMap, false /* from properties */);
     }
 
-    private static AbstractConfigObject fromPathMap(ConfigOrigin origin,
+    private static AbstractConfigObject fromPathMap(ConfigOrigin valueOrigin, ConfigOrigin origin,
             Map<Path, Object> pathMap, boolean convertedFromProperties) {
         /*
          * First, build a list of paths that will have values, either string or
@@ -149,7 +154,7 @@ final class PropertiesParser {
                     value = null;
                 }
             } else {
-                value = ConfigImpl.fromAnyRef(pathMap.get(path), origin,
+                value = ConfigImpl.fromAnyRef(pathMap.get(path), origin, origin,
                         FromMapMode.KEYS_ARE_PATHS);
             }
             if (value != null)
@@ -191,7 +196,7 @@ final class PropertiesParser {
         }
 
         // return root config object
-        return new SimpleConfigObject(origin, root, ResolveStatus.RESOLVED,
+        return new SimpleConfigObject(valueOrigin, root, ResolveStatus.RESOLVED,
                 false /* ignoresFallbacks */);
     }
 }


### PR DESCRIPTION
This fix #237 and #193. 

To get a ConfigValue with comments, just use
```java
ConfigValueFactory.fromAnyRef("some values", "Origin description", new String[] {"Comments"});
```
To edit comments, use
```java
ConfigValueFactory.fromAnyRef(theConfigValue, "Origin description", new String[] {"Comments"});
```
This should support all kinds of ```ConfigValue```.

And to get a ConfigObject with comments, use
```java
Map values = new HashMap();
values.put("key", ConfigValueFactory.fromAnyRef("value", null, new String[] {"Comments on value"}));
ConfigObject config = ConfigValueFactory.fromMap(values, null, new String[] {"Comments on object"});
```
And when rendering,
```java
ConfigObject root = config.atKey("config").root();
String result = root.render(ConfigRenderOptions.defaults().setFormatted(true).setJson(false).setOriginComments(false));
```
will give
```
# Comments on object
config {
    # Comments on value
    key=value
}
```