### PR TITLE
Support only Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 language: scala
 
 jdk:
-  - openjdk6
+  - oraclejdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test


### PR DESCRIPTION
I wanted to suggest this idea for a few reasons. Java 7 is EOL in April and will no longer be receiving updates. Akka is dropping Java 7 support in version 2.4. Play has also decided to drop support for Java 7 in Play 2.4. Supporting Java 8 would be nice because it would allow us to do autoconversions to the new time API like java.time.Duration