### PR TITLE
In render, put comment char in front of every description line

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigList.java
@@ -211,10 +211,15 @@ final class SimpleConfigList extends AbstractConfigValue implements ConfigList, 
                 sb.append('\n');
             for (AbstractConfigValue v : value) {
                 if (options.getOriginComments()) {
-                    indent(sb, indent + 1, options);
-                    sb.append("# ");
-                    sb.append(v.origin().description());
-                    sb.append("\n");
+                    String[] lines = v.origin().description().split("\n");
+                    for (String l : lines) {
+                        indent(sb, indent + 1, options);
+                        sb.append('#');
+                        if (!l.isEmpty())
+                            sb.append(' ');
+                        sb.append(l);
+                        sb.append("\n");
+                    }
                 }
                 if (options.getComments()) {
                     for (String comment : v.origin().comments()) {

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -444,10 +444,15 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
                 v = value.get(k);
 
                 if (options.getOriginComments()) {
-                    indent(sb, innerIndent, options);
-                    sb.append("# ");
-                    sb.append(v.origin().description());
-                    sb.append("\n");
+                    String[] lines = v.origin().description().split("\n");
+                    for (String l : lines) {
+                        indent(sb, indent + 1, options);
+                        sb.append('#');
+                        if (!l.isEmpty())
+                            sb.append(' ');
+                        sb.append(l);
+                        sb.append("\n");
+                    }
                 }
                 if (options.getComments()) {
                     for (String comment : v.origin().comments()) {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -938,4 +938,25 @@ class ConfigValueTest extends TestUtils {
             assertEquals(bottom(v), bottom(deserialized))
         }
     }
+
+    @Test
+    def renderWithNewlinesInDescription(): Unit = {
+        val v = ConfigValueFactory.fromAnyRef(89, "this is a description\nwith some\nnewlines")
+        val list = new SimpleConfigList(SimpleConfigOrigin.newSimple("\n5\n6\n7\n"),
+            java.util.Collections.singletonList(v.asInstanceOf[AbstractConfigValue]))
+        val conf = ConfigFactory.empty().withValue("bar", list)
+        val rendered = conf.root.render()
+        def assertHas(s: String): Unit =
+            assertTrue(s"has ${s.replace("\n", "\\n")} in it", rendered.contains(s))
+        assertHas("is a description\n")
+        assertHas("with some\n")
+        assertHas("newlines\n")
+        assertHas("#\n")
+        assertHas("5\n")
+        assertHas("6\n")
+        assertHas("7\n")
+        val parsed = ConfigFactory.parseString(rendered)
+
+        assertEquals(conf, parsed)
+    }
 }


### PR DESCRIPTION
Fixes #239 that multiline descriptions created unparseable output.