### PR TITLE
Allow unquoted whitespace between substitutions that expand to objects/l...

### DIFF
--- a/HOCON.md
+++ b/HOCON.md
@@ -383,6 +383,15 @@ A common use of array concatenation is to add to paths:
     path = [ /bin ]
     path = ${path} [ /usr/bin ]
 
+#### Note: Concatenation with whitespace and substitutions
+
+When concatenating substitutions such as `${foo} ${bar}`, the
+substitutions may turn out to be strings (which makes the
+whitespace between them significant) or may turn out to be objects
+or lists (which makes it irrelevant). Unquoted whitespace must be
+ignored in between substitutions which resolve to objects or
+lists. Quoted whitespace should be an error.
+
 #### Note: Arrays without commas or newlines
 
 Arrays allow you to use newlines instead of commas, but not

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -227,7 +227,7 @@ public class ConfigImpl {
                 return defaultFalseValue;
             }
         } else if (object instanceof String) {
-            return new ConfigString(origin, (String) object);
+            return new ConfigString.Quoted(origin, (String) object);
         } else if (object instanceof Number) {
             // here we always keep the same type that was passed to us,
             // rather than figuring out if a Long would fit in an Int
@@ -346,7 +346,7 @@ public class ConfigImpl {
         for (Map.Entry<String, String> entry : env.entrySet()) {
             String key = entry.getKey();
             m.put(key,
-                    new ConfigString(SimpleConfigOrigin.newSimple("env var " + key), entry
+                    new ConfigString.Quoted(SimpleConfigOrigin.newSimple("env var " + key), entry
                             .getValue()));
         }
         return new SimpleConfigObject(SimpleConfigOrigin.newSimple("env variables"),

--- a/config/src/main/java/com/typesafe/config/impl/DefaultTransformer.java
+++ b/config/src/main/java/com/typesafe/config/impl/DefaultTransformer.java
@@ -64,7 +64,7 @@ final class DefaultTransformer {
             switch (value.valueType()) {
             case NUMBER: // FALL THROUGH
             case BOOLEAN:
-                return new ConfigString(value.origin(),
+                return new ConfigString.Quoted(value.origin(),
                         value.transformToString());
             case NULL:
                 // want to be sure this throws instead of returning "null" as a

--- a/config/src/main/java/com/typesafe/config/impl/Parser.java
+++ b/config/src/main/java/com/typesafe/config/impl/Parser.java
@@ -513,7 +513,7 @@ final class Parser {
                 // or substitution already.
                 v = Tokens.getValue(t.token);
             } else if (Tokens.isUnquotedText(t.token)) {
-                v = new ConfigString(t.token.origin(), Tokens.getUnquotedText(t.token));
+                v = new ConfigString.Unquoted(t.token.origin(), Tokens.getUnquotedText(t.token));
             } else if (Tokens.isSubstitution(t.token)) {
                 v = new ConfigReference(t.token.origin(), tokenToSubstitutionExpression(t.token));
             } else if (t.token == Tokens.OPEN_CURLY) {

--- a/config/src/main/java/com/typesafe/config/impl/PropertiesParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/PropertiesParser.java
@@ -143,7 +143,7 @@ final class PropertiesParser {
             AbstractConfigValue value;
             if (convertedFromProperties) {
                 if (rawValue instanceof String) {
-                    value = new ConfigString(origin, (String) rawValue);
+                    value = new ConfigString.Quoted(origin, (String) rawValue);
                 } else {
                     // silently ignore non-string values in Properties
                     value = null;

--- a/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
@@ -342,7 +342,7 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
             String sd = in.readUTF();
             return new ConfigDouble(origin, vd, sd);
         case STRING:
-            return new ConfigString(origin, in.readUTF());
+            return new ConfigString.Quoted(origin, in.readUTF());
         case LIST:
             int listSize = in.readInt();
             List<AbstractConfigValue> list = new ArrayList<AbstractConfigValue>(listSize);

--- a/config/src/main/java/com/typesafe/config/impl/Tokens.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokens.java
@@ -403,7 +403,7 @@ final class Tokens {
     }
 
     static Token newString(ConfigOrigin origin, String value) {
-        return newValue(new ConfigString(origin, value));
+        return newValue(new ConfigString.Quoted(origin, value));
     }
 
     static Token newInt(ConfigOrigin origin, int value, String originalText) {

--- a/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
@@ -70,7 +70,7 @@ class JsonTest extends TestUtils {
             case lift.JDouble(d) =>
                 doubleValue(d)
             case lift.JString(s) =>
-                new ConfigString(fakeOrigin(), s)
+                new ConfigString.Quoted(fakeOrigin(), s)
             case lift.JNull =>
                 new ConfigNull(fakeOrigin())
             case lift.JNothing =>

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -573,7 +573,7 @@ abstract trait TestUtils {
     protected def longValue(l: Long) = new ConfigLong(fakeOrigin(), l, null)
     protected def boolValue(b: Boolean) = new ConfigBoolean(fakeOrigin(), b)
     protected def nullValue() = new ConfigNull(fakeOrigin())
-    protected def stringValue(s: String) = new ConfigString(fakeOrigin(), s)
+    protected def stringValue(s: String) = new ConfigString.Quoted(fakeOrigin(), s)
     protected def doubleValue(d: Double) = new ConfigDouble(fakeOrigin(), d, null)
 
     protected def parseObject(s: String) = {

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -136,7 +136,7 @@ class TokenizerTest extends TestUtils {
     @Test
     def tokenizerUnescapeStrings(): Unit = {
         case class UnescapeTest(escaped: String, result: ConfigString)
-        implicit def pair2unescapetest(pair: (String, String)): UnescapeTest = UnescapeTest(pair._1, new ConfigString(fakeOrigin(), pair._2))
+        implicit def pair2unescapetest(pair: (String, String)): UnescapeTest = UnescapeTest(pair._1, new ConfigString.Quoted(fakeOrigin(), pair._2))
 
         // getting the actual 6 chars we want in a string is a little pesky.
         // \u005C is backslash. Just prove we're doing it right here.


### PR DESCRIPTION
...ists

Fixes #212 that object and list substitutions could not have
whitespace in between.

This patch carries quoted-ness into ConfigString, which is somewhat
bogus, and we may be able to clean it up later if we start to track
the tokens that each value originates from.