### PR TITLE
Add lossless tokens

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/Parser.java
+++ b/config/src/main/java/com/typesafe/config/impl/Parser.java
@@ -203,7 +203,7 @@ final class Parser {
                 }
 
                 previous = next;
-                next = tokens.next();
+                next = nextTokenFromIterator();
             }
 
             // put our concluding token in the queue with all the comments
@@ -219,7 +219,7 @@ final class Parser {
 
         private TokenWithComments popTokenWithoutTrailingComment() {
             if (buffer.isEmpty()) {
-                Token t = tokens.next();
+                Token t = nextTokenFromIterator();
                 if (Tokens.isComment(t)) {
                     consolidateCommentBlock(t);
                     return buffer.pop();
@@ -243,7 +243,7 @@ final class Parser {
             if (!attractsTrailingComments(withPrecedingComments.token)) {
                 return withPrecedingComments;
             } else if (buffer.isEmpty()) {
-                Token after = tokens.next();
+                Token after = nextTokenFromIterator();
                 if (Tokens.isComment(after)) {
                     return withPrecedingComments.add(after);
                 } else {
@@ -316,6 +316,16 @@ final class Parser {
             if (newNumber >= 0)
                 lineNumber = newNumber;
 
+            return t;
+        }
+
+        // Grabs the next Token off of the TokenIterator, ignoring
+        // IgnoredWhitespace tokens
+        private Token nextTokenFromIterator() {
+            Token t;
+            do {
+                t = tokens.next();
+            } while (Tokens.isIgnoredWhitespace(t));
             return t;
         }
 
@@ -1063,6 +1073,11 @@ final class Parser {
 
         while (expression.hasNext()) {
             Token t = expression.next();
+
+            // Ignore all IgnoredWhitespace tokens
+            if (Tokens.isIgnoredWhitespace(t))
+                continue;
+
             if (Tokens.isValueWithType(t, ConfigValueType.STRING)) {
                 AbstractConfigValue v = Tokens.getValue(t);
                 // this is a quoted string; so any periods

--- a/config/src/main/java/com/typesafe/config/impl/Parser.java
+++ b/config/src/main/java/com/typesafe/config/impl/Parser.java
@@ -203,7 +203,7 @@ final class Parser {
                 }
 
                 previous = next;
-                next = nextTokenFromIterator();
+                next = nextTokenIgnoringWhitespace();
             }
 
             // put our concluding token in the queue with all the comments
@@ -219,7 +219,7 @@ final class Parser {
 
         private TokenWithComments popTokenWithoutTrailingComment() {
             if (buffer.isEmpty()) {
-                Token t = nextTokenFromIterator();
+                Token t = nextTokenIgnoringWhitespace();
                 if (Tokens.isComment(t)) {
                     consolidateCommentBlock(t);
                     return buffer.pop();
@@ -243,7 +243,7 @@ final class Parser {
             if (!attractsTrailingComments(withPrecedingComments.token)) {
                 return withPrecedingComments;
             } else if (buffer.isEmpty()) {
-                Token after = nextTokenFromIterator();
+                Token after = nextTokenIgnoringWhitespace();
                 if (Tokens.isComment(after)) {
                     return withPrecedingComments.add(after);
                 } else {
@@ -321,7 +321,7 @@ final class Parser {
 
         // Grabs the next Token off of the TokenIterator, ignoring
         // IgnoredWhitespace tokens
-        private Token nextTokenFromIterator() {
+        private Token nextTokenIgnoringWhitespace() {
             Token t;
             do {
                 t = tokens.next();

--- a/config/src/main/java/com/typesafe/config/impl/Token.java
+++ b/config/src/main/java/com/typesafe/config/impl/Token.java
@@ -10,25 +10,33 @@ class Token {
     final private TokenType tokenType;
     final private String debugString;
     final private ConfigOrigin origin;
+    final private String tokenText;
 
     Token(TokenType tokenType, ConfigOrigin origin) {
         this(tokenType, origin, null);
     }
 
-    Token(TokenType tokenType, ConfigOrigin origin, String debugString) {
+    Token(TokenType tokenType, ConfigOrigin origin, String tokenText) {
+        this(tokenType, origin, tokenText, null);
+    }
+
+    Token(TokenType tokenType, ConfigOrigin origin, String tokenText, String debugString) {
         this.tokenType = tokenType;
         this.origin = origin;
         this.debugString = debugString;
+        this.tokenText = tokenText;
     }
 
     // this is used for singleton tokens like COMMA or OPEN_CURLY
-    static Token newWithoutOrigin(TokenType tokenType, String debugString) {
-        return new Token(tokenType, null, debugString);
+    static Token newWithoutOrigin(TokenType tokenType, String debugString, String tokenText) {
+        return new Token(tokenType, null, tokenText, debugString);
     }
 
     final TokenType tokenType() {
         return tokenType;
     }
+
+    final String tokenText() { return tokenText; }
 
     // this is final because we don't always use the origin() accessor,
     // and we don't because it throws if origin is null

--- a/config/src/main/java/com/typesafe/config/impl/Token.java
+++ b/config/src/main/java/com/typesafe/config/impl/Token.java
@@ -36,7 +36,7 @@ class Token {
         return tokenType;
     }
 
-    final String tokenText() { return tokenText; }
+    public String tokenText() { return tokenText; }
 
     // this is final because we don't always use the origin() accessor,
     // and we don't because it throws if origin is null

--- a/config/src/main/java/com/typesafe/config/impl/TokenType.java
+++ b/config/src/main/java/com/typesafe/config/impl/TokenType.java
@@ -16,6 +16,7 @@ enum TokenType {
     VALUE,
     NEWLINE,
     UNQUOTED_TEXT,
+    IGNORED_WHITESPACE,
     SUBSTITUTION,
     PROBLEM,
     COMMENT,

--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -278,10 +278,12 @@ final class Tokenizer {
         // ONE char has always been consumed, either the # or the first /, but
         // not both slashes
         private Token pullComment(int firstChar) {
+            boolean doubleSlash = false;
             if (firstChar == '/') {
                 int discard = nextCharRaw();
                 if (discard != '/')
                     throw new ConfigException.BugOrBroken("called pullComment but // not seen");
+                doubleSlash = true;
             }
 
             StringBuilder sb = new StringBuilder();
@@ -289,7 +291,7 @@ final class Tokenizer {
                 int c = nextCharRaw();
                 if (c == -1 || c == '\n') {
                     putBack(c);
-                    return Tokens.newComment(lineOrigin, sb.toString());
+                    return Tokens.newComment(lineOrigin, sb.toString(), doubleSlash);
                 } else {
                     sb.appendCodePoint(c);
                 }

--- a/config/src/main/java/com/typesafe/config/impl/Tokens.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokens.java
@@ -198,8 +198,8 @@ final class Tokens {
     static private class Comment extends Token {
         final private String text;
 
-        Comment(ConfigOrigin origin, String text) {
-            super(TokenType.COMMENT, origin);
+        Comment(ConfigOrigin origin, String text, boolean doubleSlash) {
+            super(TokenType.COMMENT, origin, (doubleSlash? "//" : "#") + text);
             this.text = text;
         }
 
@@ -409,8 +409,8 @@ final class Tokens {
         return new Problem(origin, what, message, suggestQuotes, cause);
     }
 
-    static Token newComment(ConfigOrigin origin, String text) {
-        return new Comment(origin, text);
+    static Token newComment(ConfigOrigin origin, String text, boolean doubleSlash) {
+        return new Comment(origin, text, doubleSlash);
     }
 
     static Token newUnquotedText(ConfigOrigin origin, String s) {

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -616,7 +616,7 @@ abstract trait TestUtils {
     def tokenInt(i: Int) = Tokens.newInt(fakeOrigin(), i, null)
     def tokenLong(l: Long) = Tokens.newLong(fakeOrigin(), l, null)
     def tokenLine(line: Int) = Tokens.newLine(fakeOrigin.withLineNumber(line))
-    def tokenComment(text: String) = Tokens.newComment(fakeOrigin(), text)
+    def tokenComment(text: String, doubleSlash : Boolean) = Tokens.newComment(fakeOrigin(), text, doubleSlash)
     def tokenWhitespace(text: String) = Tokens.newIgnoredWhitespace(fakeOrigin(), text)
 
     private def tokenMaybeOptionalSubstitution(optional: Boolean, expression: Token*) = {

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -611,12 +611,13 @@ abstract trait TestUtils {
     def tokenFalse = Tokens.newBoolean(fakeOrigin(), false)
     def tokenNull = Tokens.newNull(fakeOrigin())
     def tokenUnquoted(s: String) = Tokens.newUnquotedText(fakeOrigin(), s)
-    def tokenString(s: String) = Tokens.newString(fakeOrigin(), s)
+    def tokenString(s: String) = Tokens.newString(fakeOrigin(), s, s)
     def tokenDouble(d: Double) = Tokens.newDouble(fakeOrigin(), d, null)
     def tokenInt(i: Int) = Tokens.newInt(fakeOrigin(), i, null)
     def tokenLong(l: Long) = Tokens.newLong(fakeOrigin(), l, null)
     def tokenLine(line: Int) = Tokens.newLine(fakeOrigin.withLineNumber(line))
     def tokenComment(text: String) = Tokens.newComment(fakeOrigin(), text)
+    def tokenWhitespace(text: String) = Tokens.newIgnoredWhitespace(fakeOrigin(), text)
 
     private def tokenMaybeOptionalSubstitution(optional: Boolean, expression: Token*) = {
         val l = new java.util.ArrayList[Token]
@@ -655,6 +656,10 @@ abstract trait TestUtils {
     def tokenizeAsList(s: String) = {
         import scala.collection.JavaConverters._
         tokenize(s).asScala.toList
+    }
+
+    def tokenizeAsString(s: String) = {
+        Tokenizer.render(tokenize(s))
     }
 
     // this is importantly NOT using Path.newPath, which relies on

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -616,7 +616,8 @@ abstract trait TestUtils {
     def tokenInt(i: Int) = Tokens.newInt(fakeOrigin(), i, null)
     def tokenLong(l: Long) = Tokens.newLong(fakeOrigin(), l, null)
     def tokenLine(line: Int) = Tokens.newLine(fakeOrigin.withLineNumber(line))
-    def tokenComment(text: String, doubleSlash : Boolean) = Tokens.newComment(fakeOrigin(), text, doubleSlash)
+    def tokenCommentDoubleSlash(text: String) = Tokens.newCommentDoubleSlash(fakeOrigin(), text)
+    def tokenCommentHash(text: String) = Tokens.newCommentHash(fakeOrigin(), text)
     def tokenWhitespace(text: String) = Tokens.newIgnoredWhitespace(fakeOrigin(), text)
 
     private def tokenMaybeOptionalSubstitution(optional: Boolean, expression: Token*) = {

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -134,7 +134,7 @@ class TokenizerTest extends TestUtils {
         tokenizerTest(List(tokenUnquoted("a/b/c/")), "a/b/c/")
         tokenizerTest(List(tokenUnquoted("/")), "/")
         tokenizerTest(List(tokenUnquoted("/"), tokenUnquoted(" "), tokenUnquoted("/")), "/ /")
-        //tokenizerTest(List(tokenComment("")), "//")
+        tokenizerTest(List(tokenComment("", true)), "//")
     }
 
     @Test
@@ -283,17 +283,22 @@ class TokenizerTest extends TestUtils {
 
     @Test
     def commentsHandledInVariousContexts() {
-        //        tokenizerTest(List(tokenString("//bar")), "\"//bar\"")
-        //        tokenizerTest(List(tokenString("#bar")), "\"#bar\"")
-        //        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar//comment")
-        //        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar#comment")
-        //        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10//comment")
-        //        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10#comment")
-        //        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14//comment")
-        //        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14#comment")
-        //        // be sure we keep the newline
-        //        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10//comment\n12")
-        //        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10#comment\n12")
+        tokenizerTest(List(tokenString("//bar")), "\"//bar\"")
+        tokenizerTest(List(tokenString("#bar")), "\"#bar\"")
+        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment", true)), "bar//comment")
+        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment", false)), "bar#comment")
+        tokenizerTest(List(tokenInt(10), tokenComment("comment", true)), "10//comment")
+        tokenizerTest(List(tokenInt(10), tokenComment("comment", false)), "10#comment")
+        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment", true)), "3.14//comment")
+        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment", false)), "3.14#comment")
+        // be sure we keep the newline
+        tokenizerTest(List(tokenInt(10), tokenComment("comment", true), tokenLine(1), tokenInt(12)), "10//comment\n12")
+        tokenizerTest(List(tokenInt(10), tokenComment("comment", false), tokenLine(1), tokenInt(12)), "10#comment\n12")
+        // be sure we handle multi-line comments
+        tokenizerTest(List(tokenComment("comment", true), tokenLine(1), tokenComment("comment2", true)),
+                      "//comment\n//comment2")
+        tokenizerTest(List(tokenComment("comment", false), tokenLine(1), tokenComment("comment2", false)),
+                      "#comment\n#comment2")
     }
 
     @Test

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -20,17 +20,15 @@ class TokenizerTest extends TestUtils {
     @Test
     def tokenizeEmptyString() {
         val source = ""
-        assertEquals(List(Tokens.START, Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List()
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeNewlines() {
         val source = "\n\n"
-        assertEquals(List(Tokens.START, tokenLine(1), tokenLine(2), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenLine(1), tokenLine(2))
+        tokenizerTest(expected, source)
     }
 
     @Test
@@ -39,20 +37,19 @@ class TokenizerTest extends TestUtils {
         // but spec is unclear to me when spaces are required, and banning them
         // is actually extra work).
         val source = """,:=}{][+="foo"""" + "\"\"\"bar\"\"\"" + """true3.14false42null${a.b}${?x.y}${"c.d"}""" + "\n"
-        val expected = List(Tokens.START, Tokens.COMMA, Tokens.COLON, Tokens.EQUALS, Tokens.CLOSE_CURLY,
+        val expected = List(Tokens.COMMA, Tokens.COLON, Tokens.EQUALS, Tokens.CLOSE_CURLY,
             Tokens.OPEN_CURLY, Tokens.CLOSE_SQUARE, Tokens.OPEN_SQUARE, Tokens.PLUS_EQUALS, tokenString("foo"),
             tokenString("bar"), tokenTrue, tokenDouble(3.14), tokenFalse,
             tokenLong(42), tokenNull, tokenSubstitution(tokenUnquoted("a.b")),
             tokenOptionalSubstitution(tokenUnquoted("x.y")),
-            tokenKeySubstitution("c.d"), tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+            tokenKeySubstitution("c.d"), tokenLine(1))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeAllTypesWithSingleSpaces() {
         val source = """ , : = } { ] [ += "foo" """ + "\"\"\"bar\"\"\"" + """ 42 true 3.14 false null ${a.b} ${?x.y} ${"c.d"} """ + "\n "
-        val expected = List(Tokens.START, tokenWhitespace(" "), Tokens.COMMA, tokenWhitespace(" "), Tokens.COLON, tokenWhitespace(" "),
+        val expected = List(tokenWhitespace(" "), Tokens.COMMA, tokenWhitespace(" "), Tokens.COLON, tokenWhitespace(" "),
             Tokens.EQUALS, tokenWhitespace(" "), Tokens.CLOSE_CURLY, tokenWhitespace(" "), Tokens.OPEN_CURLY, tokenWhitespace(" "),
             Tokens.CLOSE_SQUARE, tokenWhitespace(" "), Tokens.OPEN_SQUARE, tokenWhitespace(" "), Tokens.PLUS_EQUALS, tokenWhitespace(" "),
             tokenString("foo"), tokenUnquoted(" "), tokenString("bar"), tokenUnquoted(" "), tokenLong(42), tokenUnquoted(" "),
@@ -60,15 +57,14 @@ class TokenizerTest extends TestUtils {
             tokenUnquoted(" "), tokenSubstitution(tokenUnquoted("a.b")), tokenUnquoted(" "),
             tokenOptionalSubstitution(tokenUnquoted("x.y")), tokenUnquoted(" "),
             tokenKeySubstitution("c.d"), tokenWhitespace(" "),
-            tokenLine(1), tokenWhitespace(" "), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+            tokenLine(1), tokenWhitespace(" "))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeAllTypesWithMultipleSpaces() {
         val source = """   ,   :   =   }   {   ]   [   +=   "foo"   """ + "\"\"\"bar\"\"\"" + """   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${"c.d"}  """ + "\n   "
-        val expected = List(Tokens.START, tokenWhitespace("   "), Tokens.COMMA, tokenWhitespace("   "), Tokens.COLON, tokenWhitespace("   "),
+        val expected = List(tokenWhitespace("   "), Tokens.COMMA, tokenWhitespace("   "), Tokens.COLON, tokenWhitespace("   "),
             Tokens.EQUALS, tokenWhitespace("   "), Tokens.CLOSE_CURLY, tokenWhitespace("   "), Tokens.OPEN_CURLY, tokenWhitespace("   "), Tokens.CLOSE_SQUARE,
             tokenWhitespace("   "), Tokens.OPEN_SQUARE, tokenWhitespace("   "), Tokens.PLUS_EQUALS, tokenWhitespace("   "), tokenString("foo"),
             tokenUnquoted("   "), tokenString("bar"), tokenUnquoted("   "), tokenLong(42), tokenUnquoted("   "), tokenTrue, tokenUnquoted("   "),
@@ -76,57 +72,50 @@ class TokenizerTest extends TestUtils {
             tokenUnquoted("   "), tokenSubstitution(tokenUnquoted("a.b")), tokenUnquoted("   "),
             tokenOptionalSubstitution(tokenUnquoted("x.y")), tokenUnquoted("   "),
             tokenKeySubstitution("c.d"), tokenWhitespace("  "),
-            tokenLine(1), tokenWhitespace("   "), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+            tokenLine(1), tokenWhitespace("   "))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeTrueAndUnquotedText() {
         val source = """truefoo"""
-        val expected = List(Tokens.START, tokenTrue, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenTrue, tokenUnquoted("foo"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeFalseAndUnquotedText() {
         val source = """falsefoo"""
-        val expected = List(Tokens.START, tokenFalse, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenFalse, tokenUnquoted("foo"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeNullAndUnquotedText() {
         val source = """nullfoo"""
-        val expected = List(Tokens.START, tokenNull, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenNull, tokenUnquoted("foo"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeUnquotedTextContainingTrue() {
         val source = """footrue"""
-        val expected = List(Tokens.START, tokenUnquoted("footrue"), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenUnquoted("footrue"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeUnquotedTextContainingSpaceTrue() {
         val source = """foo true"""
-        val expected = List(Tokens.START, tokenUnquoted("foo"), tokenUnquoted(" "), tokenTrue, Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenUnquoted("foo"), tokenUnquoted(" "), tokenTrue)
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeTrueAndSpaceAndUnquotedText() {
         val source = """true foo"""
-        val expected = List(Tokens.START, tokenTrue, tokenUnquoted(" "), tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenTrue, tokenUnquoted(" "), tokenUnquoted("foo"))
+        tokenizerTest(expected, source)
     }
 
     @Test
@@ -134,36 +123,33 @@ class TokenizerTest extends TestUtils {
         tokenizerTest(List(tokenUnquoted("a/b/c/")), "a/b/c/")
         tokenizerTest(List(tokenUnquoted("/")), "/")
         tokenizerTest(List(tokenUnquoted("/"), tokenUnquoted(" "), tokenUnquoted("/")), "/ /")
-        tokenizerTest(List(tokenComment("", true)), "//")
+        tokenizerTest(List(tokenCommentDoubleSlash("")), "//")
     }
 
     @Test
     def tokenizeUnquotedTextKeepsSpaces() {
         val source = "    foo     \n"
-        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"), tokenWhitespace("     "),
-            tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenWhitespace("    "), tokenUnquoted("foo"), tokenWhitespace("     "),
+            tokenLine(1))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeUnquotedTextKeepsInternalSpaces() {
         val source = "    foo  bar baz   \n"
-        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"), tokenUnquoted("  "),
+        val expected = List(tokenWhitespace("    "), tokenUnquoted("foo"), tokenUnquoted("  "),
             tokenUnquoted("bar"), tokenUnquoted(" "), tokenUnquoted("baz"), tokenWhitespace("   "),
-            tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList("    foo  bar baz   \n"))
-        assertEquals(source, tokenizeAsString(source))
+            tokenLine(1))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizeMixedUnquotedQuoted() {
         val source = "    foo\"bar\"baz   \n"
-        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"),
+        val expected = List(tokenWhitespace("    "), tokenUnquoted("foo"),
             tokenString("bar"), tokenUnquoted("baz"), tokenWhitespace("   "),
-            tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList("    foo\"bar\"baz   \n"))
-        assertEquals(source, tokenizeAsString(source))
+            tokenLine(1))
+        tokenizerTest(expected, source)
     }
 
     @Test
@@ -185,10 +171,9 @@ class TokenizerTest extends TestUtils {
 
         for (t <- tests) {
             describeFailure(t.toString) {
-                assertEquals(List(Tokens.START, tokenWhitespace(" "), Tokens.newValue(t.result, t.toString),
-                    tokenWhitespace(" "), Tokens.END),
-                    tokenizeAsList(t.escaped))
-                assertEquals(t.escaped, tokenizeAsString(t.escaped))
+                val expected = List(tokenWhitespace(" "), Tokens.newValue(t.result, t.toString),
+                  tokenWhitespace(" "))
+                tokenizerTest(expected, t.escaped)
             }
         }
     }
@@ -218,41 +203,36 @@ class TokenizerTest extends TestUtils {
     @Test
     def tokenizerEmptyTripleQuoted(): Unit = {
         val source = "\"\"\"\"\"\""
-        assertEquals(List(Tokens.START, tokenString(""), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenString(""))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizerTrivialTripleQuoted(): Unit = {
         val source = "\"\"\"bar\"\"\""
-        assertEquals(List(Tokens.START, tokenString("bar"), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenString("bar"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizerNoEscapesInTripleQuoted(): Unit = {
         val source = "\"\"\"\\n\"\"\""
-        assertEquals(List(Tokens.START, tokenString("\\n"), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenString("\\n"))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizerTrailingQuotesInTripleQuoted(): Unit = {
         val source = "\"\"\"\"\"\"\"\"\""
-        assertEquals(List(Tokens.START, tokenString("\"\"\""), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenString("\"\"\""))
+        tokenizerTest(expected, source)
     }
 
     @Test
     def tokenizerNewlineInTripleQuoted(): Unit = {
         val source = "\"\"\"foo\nbar\"\"\""
-        assertEquals(List(Tokens.START, tokenString("foo\nbar"), Tokens.END),
-            tokenizeAsList(source))
-        assertEquals(source, tokenizeAsString(source))
+        val expected = List(tokenString("foo\nbar"))
+        tokenizerTest(expected, source)
     }
 
     @Test
@@ -274,9 +254,8 @@ class TokenizerTest extends TestUtils {
 
         for (t <- tests) {
             describeFailure(t.toString()) {
-                assertEquals(List(Tokens.START, t.result, Tokens.END),
-                    tokenizeAsList(t.s))
-                assertEquals(t.s, tokenizeAsString(t.s))
+                val expected = List(t.result)
+                tokenizerTest(expected, t.s)
             }
         }
     }
@@ -285,20 +264,30 @@ class TokenizerTest extends TestUtils {
     def commentsHandledInVariousContexts() {
         tokenizerTest(List(tokenString("//bar")), "\"//bar\"")
         tokenizerTest(List(tokenString("#bar")), "\"#bar\"")
-        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment", true)), "bar//comment")
-        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment", false)), "bar#comment")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment", true)), "10//comment")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment", false)), "10#comment")
-        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment", true)), "3.14//comment")
-        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment", false)), "3.14#comment")
+        tokenizerTest(List(tokenUnquoted("bar"), tokenCommentDoubleSlash("comment")), "bar//comment")
+        tokenizerTest(List(tokenUnquoted("bar"), tokenCommentHash("comment")), "bar#comment")
+        tokenizerTest(List(tokenInt(10), tokenCommentDoubleSlash("comment")), "10//comment")
+        tokenizerTest(List(tokenInt(10), tokenCommentHash("comment")), "10#comment")
+        tokenizerTest(List(tokenDouble(3.14), tokenCommentDoubleSlash("comment")), "3.14//comment")
+        tokenizerTest(List(tokenDouble(3.14), tokenCommentHash("comment")), "3.14#comment")
         // be sure we keep the newline
-        tokenizerTest(List(tokenInt(10), tokenComment("comment", true), tokenLine(1), tokenInt(12)), "10//comment\n12")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment", false), tokenLine(1), tokenInt(12)), "10#comment\n12")
+        tokenizerTest(List(tokenInt(10), tokenCommentDoubleSlash("comment"), tokenLine(1), tokenInt(12)), "10//comment\n12")
+        tokenizerTest(List(tokenInt(10), tokenCommentHash("comment"), tokenLine(1), tokenInt(12)), "10#comment\n12")
         // be sure we handle multi-line comments
-        tokenizerTest(List(tokenComment("comment", true), tokenLine(1), tokenComment("comment2", true)),
+        tokenizerTest(List(tokenCommentDoubleSlash("comment"), tokenLine(1), tokenCommentDoubleSlash("comment2")),
                       "//comment\n//comment2")
-        tokenizerTest(List(tokenComment("comment", false), tokenLine(1), tokenComment("comment2", false)),
+        tokenizerTest(List(tokenCommentHash("comment"), tokenLine(1), tokenCommentHash("comment2")),
                       "#comment\n#comment2")
+        tokenizerTest(List(tokenWhitespace("        "), tokenCommentDoubleSlash("comment\r"),
+                           tokenLine(1), tokenWhitespace("        "), tokenCommentDoubleSlash("comment2        "),
+                           tokenLine(2), tokenCommentDoubleSlash("comment3        "),
+                           tokenLine(3), tokenLine(4), tokenCommentDoubleSlash("comment4")),
+                      "        //comment\r\n        //comment2        \n//comment3        \n\n//comment4")
+        tokenizerTest(List(tokenWhitespace("        "), tokenCommentDoubleSlash("comment\r"),
+                           tokenLine(1), tokenWhitespace("        "), tokenCommentDoubleSlash("comment2        "),
+                           tokenLine(2), tokenCommentDoubleSlash("comment3        "),
+                           tokenLine(3), tokenLine(4), tokenCommentDoubleSlash("comment4")),
+                      "        //comment\r\n        //comment2        \n//comment3        \n\n//comment4")
     }
 
     @Test

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -14,18 +14,23 @@ class TokenizerTest extends TestUtils {
     private def tokenizerTest(expected: List[Token], s: String) {
         assertEquals(List(Tokens.START) ++ expected ++ List(Tokens.END),
             tokenizeAsList(s))
+        assertEquals(s, tokenizeAsString(s))
     }
 
     @Test
     def tokenizeEmptyString() {
+        val source = ""
         assertEquals(List(Tokens.START, Tokens.END),
-            tokenizeAsList(""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeNewlines() {
+        val source = "\n\n"
         assertEquals(List(Tokens.START, tokenLine(1), tokenLine(2), Tokens.END),
-            tokenizeAsList("\n\n"))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
@@ -33,75 +38,95 @@ class TokenizerTest extends TestUtils {
         // all token types with no spaces (not sure JSON spec wants this to work,
         // but spec is unclear to me when spaces are required, and banning them
         // is actually extra work).
+        val source = """,:=}{][+="foo"""" + "\"\"\"bar\"\"\"" + """true3.14false42null${a.b}${?x.y}${"c.d"}""" + "\n"
         val expected = List(Tokens.START, Tokens.COMMA, Tokens.COLON, Tokens.EQUALS, Tokens.CLOSE_CURLY,
             Tokens.OPEN_CURLY, Tokens.CLOSE_SQUARE, Tokens.OPEN_SQUARE, Tokens.PLUS_EQUALS, tokenString("foo"),
             tokenString("bar"), tokenTrue, tokenDouble(3.14), tokenFalse,
             tokenLong(42), tokenNull, tokenSubstitution(tokenUnquoted("a.b")),
             tokenOptionalSubstitution(tokenUnquoted("x.y")),
             tokenKeySubstitution("c.d"), tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList(""",:=}{][+="foo"""" + "\"\"\"bar\"\"\"" + """true3.14false42null${a.b}${?x.y}${"c.d"}""" + "\n"))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeAllTypesWithSingleSpaces() {
-        val expected = List(Tokens.START, Tokens.COMMA, Tokens.COLON, Tokens.EQUALS, Tokens.CLOSE_CURLY,
-            Tokens.OPEN_CURLY, Tokens.CLOSE_SQUARE, Tokens.OPEN_SQUARE, Tokens.PLUS_EQUALS, tokenString("foo"),
-            tokenUnquoted(" "), tokenString("bar"), tokenUnquoted(" "), tokenLong(42), tokenUnquoted(" "), tokenTrue, tokenUnquoted(" "),
-            tokenDouble(3.14), tokenUnquoted(" "), tokenFalse, tokenUnquoted(" "), tokenNull,
+        val source = """ , : = } { ] [ += "foo" """ + "\"\"\"bar\"\"\"" + """ 42 true 3.14 false null ${a.b} ${?x.y} ${"c.d"} """ + "\n "
+        val expected = List(Tokens.START, tokenWhitespace(" "), Tokens.COMMA, tokenWhitespace(" "), Tokens.COLON, tokenWhitespace(" "),
+            Tokens.EQUALS, tokenWhitespace(" "), Tokens.CLOSE_CURLY, tokenWhitespace(" "), Tokens.OPEN_CURLY, tokenWhitespace(" "),
+            Tokens.CLOSE_SQUARE, tokenWhitespace(" "), Tokens.OPEN_SQUARE, tokenWhitespace(" "), Tokens.PLUS_EQUALS, tokenWhitespace(" "),
+            tokenString("foo"), tokenUnquoted(" "), tokenString("bar"), tokenUnquoted(" "), tokenLong(42), tokenUnquoted(" "),
+            tokenTrue, tokenUnquoted(" "), tokenDouble(3.14), tokenUnquoted(" "), tokenFalse, tokenUnquoted(" "), tokenNull,
             tokenUnquoted(" "), tokenSubstitution(tokenUnquoted("a.b")), tokenUnquoted(" "),
             tokenOptionalSubstitution(tokenUnquoted("x.y")), tokenUnquoted(" "),
-            tokenKeySubstitution("c.d"),
-            tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList(""" , : = } { ] [ += "foo" """ + "\"\"\"bar\"\"\"" + """ 42 true 3.14 false null ${a.b} ${?x.y} ${"c.d"} """ + "\n "))
+            tokenKeySubstitution("c.d"), tokenWhitespace(" "),
+            tokenLine(1), tokenWhitespace(" "), Tokens.END)
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeAllTypesWithMultipleSpaces() {
-        val expected = List(Tokens.START, Tokens.COMMA, Tokens.COLON, Tokens.EQUALS, Tokens.CLOSE_CURLY,
-            Tokens.OPEN_CURLY, Tokens.CLOSE_SQUARE, Tokens.OPEN_SQUARE, Tokens.PLUS_EQUALS, tokenString("foo"),
+        val source = """   ,   :   =   }   {   ]   [   +=   "foo"   """ + "\"\"\"bar\"\"\"" + """   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${"c.d"}  """ + "\n   "
+        val expected = List(Tokens.START, tokenWhitespace("   "), Tokens.COMMA, tokenWhitespace("   "), Tokens.COLON, tokenWhitespace("   "),
+            Tokens.EQUALS, tokenWhitespace("   "), Tokens.CLOSE_CURLY, tokenWhitespace("   "), Tokens.OPEN_CURLY, tokenWhitespace("   "), Tokens.CLOSE_SQUARE,
+            tokenWhitespace("   "), Tokens.OPEN_SQUARE, tokenWhitespace("   "), Tokens.PLUS_EQUALS, tokenWhitespace("   "), tokenString("foo"),
             tokenUnquoted("   "), tokenString("bar"), tokenUnquoted("   "), tokenLong(42), tokenUnquoted("   "), tokenTrue, tokenUnquoted("   "),
             tokenDouble(3.14), tokenUnquoted("   "), tokenFalse, tokenUnquoted("   "), tokenNull,
             tokenUnquoted("   "), tokenSubstitution(tokenUnquoted("a.b")), tokenUnquoted("   "),
             tokenOptionalSubstitution(tokenUnquoted("x.y")), tokenUnquoted("   "),
-            tokenKeySubstitution("c.d"),
-            tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""   ,   :   =   }   {   ]   [   +=   "foo"   """ + "\"\"\"bar\"\"\"" + """   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${"c.d"}  """ + "\n   "))
+            tokenKeySubstitution("c.d"), tokenWhitespace("  "),
+            tokenLine(1), tokenWhitespace("   "), Tokens.END)
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeTrueAndUnquotedText() {
+        val source = """truefoo"""
         val expected = List(Tokens.START, tokenTrue, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""truefoo"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeFalseAndUnquotedText() {
+        val source = """falsefoo"""
         val expected = List(Tokens.START, tokenFalse, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""falsefoo"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeNullAndUnquotedText() {
+        val source = """nullfoo"""
         val expected = List(Tokens.START, tokenNull, tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""nullfoo"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeUnquotedTextContainingTrue() {
+        val source = """footrue"""
         val expected = List(Tokens.START, tokenUnquoted("footrue"), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""footrue"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeUnquotedTextContainingSpaceTrue() {
+        val source = """foo true"""
         val expected = List(Tokens.START, tokenUnquoted("foo"), tokenUnquoted(" "), tokenTrue, Tokens.END)
-        assertEquals(expected, tokenizeAsList("""foo true"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeTrueAndSpaceAndUnquotedText() {
+        val source = """true foo"""
         val expected = List(Tokens.START, tokenTrue, tokenUnquoted(" "), tokenUnquoted("foo"), Tokens.END)
-        assertEquals(expected, tokenizeAsList("""true foo"""))
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
@@ -109,28 +134,36 @@ class TokenizerTest extends TestUtils {
         tokenizerTest(List(tokenUnquoted("a/b/c/")), "a/b/c/")
         tokenizerTest(List(tokenUnquoted("/")), "/")
         tokenizerTest(List(tokenUnquoted("/"), tokenUnquoted(" "), tokenUnquoted("/")), "/ /")
-        tokenizerTest(List(tokenComment("")), "//")
+        //tokenizerTest(List(tokenComment("")), "//")
     }
 
     @Test
-    def tokenizeUnquotedTextTrimsSpaces() {
-        val expected = List(Tokens.START, tokenUnquoted("foo"), tokenLine(1), Tokens.END)
-        assertEquals(expected, tokenizeAsList("    foo     \n"))
+    def tokenizeUnquotedTextKeepsSpaces() {
+        val source = "    foo     \n"
+        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"), tokenWhitespace("     "),
+            tokenLine(1), Tokens.END)
+        assertEquals(expected, tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeUnquotedTextKeepsInternalSpaces() {
-        val expected = List(Tokens.START, tokenUnquoted("foo"), tokenUnquoted("  "), tokenUnquoted("bar"),
-            tokenUnquoted(" "), tokenUnquoted("baz"), tokenLine(1), Tokens.END)
+        val source = "    foo  bar baz   \n"
+        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"), tokenUnquoted("  "),
+            tokenUnquoted("bar"), tokenUnquoted(" "), tokenUnquoted("baz"), tokenWhitespace("   "),
+            tokenLine(1), Tokens.END)
         assertEquals(expected, tokenizeAsList("    foo  bar baz   \n"))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizeMixedUnquotedQuoted() {
-        val expected = List(Tokens.START, tokenUnquoted("foo"),
-            tokenString("bar"), tokenUnquoted("baz"),
+        val source = "    foo\"bar\"baz   \n"
+        val expected = List(Tokens.START, tokenWhitespace("    "), tokenUnquoted("foo"),
+            tokenString("bar"), tokenUnquoted("baz"), tokenWhitespace("   "),
             tokenLine(1), Tokens.END)
         assertEquals(expected, tokenizeAsList("    foo\"bar\"baz   \n"))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
@@ -147,13 +180,15 @@ class TokenizerTest extends TestUtils {
         val tests = List[UnescapeTest]((""" "" """, ""),
             (" \"\\u0000\" ", Character.toString(0)), // nul byte
             (""" "\"\\\/\b\f\n\r\t" """, "\"\\/\b\f\n\r\t"),
-            ("\"\\u0046\"", "F"),
-            ("\"\\u0046\\u0046\"", "FF"))
+            (" \"\\u0046\" ", "F"),
+            (" \"\\u0046\\u0046\" ", "FF"))
 
         for (t <- tests) {
             describeFailure(t.toString) {
-                assertEquals(List(Tokens.START, Tokens.newValue(t.result), Tokens.END),
+                assertEquals(List(Tokens.START, tokenWhitespace(" "), Tokens.newValue(t.result, t.toString),
+                    tokenWhitespace(" "), Tokens.END),
                     tokenizeAsList(t.escaped))
+                assertEquals(t.escaped, tokenizeAsString(t.escaped))
             }
         }
     }
@@ -182,32 +217,42 @@ class TokenizerTest extends TestUtils {
 
     @Test
     def tokenizerEmptyTripleQuoted(): Unit = {
+        val source = "\"\"\"\"\"\""
         assertEquals(List(Tokens.START, tokenString(""), Tokens.END),
-            tokenizeAsList("\"\"\"\"\"\""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizerTrivialTripleQuoted(): Unit = {
+        val source = "\"\"\"bar\"\"\""
         assertEquals(List(Tokens.START, tokenString("bar"), Tokens.END),
-            tokenizeAsList("\"\"\"bar\"\"\""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizerNoEscapesInTripleQuoted(): Unit = {
+        val source = "\"\"\"\\n\"\"\""
         assertEquals(List(Tokens.START, tokenString("\\n"), Tokens.END),
-            tokenizeAsList("\"\"\"\\n\"\"\""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizerTrailingQuotesInTripleQuoted(): Unit = {
+        val source = "\"\"\"\"\"\"\"\"\""
         assertEquals(List(Tokens.START, tokenString("\"\"\""), Tokens.END),
-            tokenizeAsList("\"\"\"\"\"\"\"\"\""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
     def tokenizerNewlineInTripleQuoted(): Unit = {
+        val source = "\"\"\"foo\nbar\"\"\""
         assertEquals(List(Tokens.START, tokenString("foo\nbar"), Tokens.END),
-            tokenizeAsList("\"\"\"foo\nbar\"\"\""))
+            tokenizeAsList(source))
+        assertEquals(source, tokenizeAsString(source))
     }
 
     @Test
@@ -231,23 +276,24 @@ class TokenizerTest extends TestUtils {
             describeFailure(t.toString()) {
                 assertEquals(List(Tokens.START, t.result, Tokens.END),
                     tokenizeAsList(t.s))
+                assertEquals(t.s, tokenizeAsString(t.s))
             }
         }
     }
 
     @Test
     def commentsHandledInVariousContexts() {
-        tokenizerTest(List(tokenString("//bar")), "\"//bar\"")
-        tokenizerTest(List(tokenString("#bar")), "\"#bar\"")
-        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar//comment")
-        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar#comment")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10//comment")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10#comment")
-        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14//comment")
-        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14#comment")
-        // be sure we keep the newline
-        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10//comment\n12")
-        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10#comment\n12")
+        //        tokenizerTest(List(tokenString("//bar")), "\"//bar\"")
+        //        tokenizerTest(List(tokenString("#bar")), "\"#bar\"")
+        //        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar//comment")
+        //        tokenizerTest(List(tokenUnquoted("bar"), tokenComment("comment")), "bar#comment")
+        //        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10//comment")
+        //        tokenizerTest(List(tokenInt(10), tokenComment("comment")), "10#comment")
+        //        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14//comment")
+        //        tokenizerTest(List(tokenDouble(3.14), tokenComment("comment")), "3.14#comment")
+        //        // be sure we keep the newline
+        //        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10//comment\n12")
+        //        tokenizerTest(List(tokenInt(10), tokenComment("comment"), tokenLine(1), tokenInt(12)), "10#comment\n12")
     }
 
     @Test


### PR DESCRIPTION
This PR allows Tokens to keep track of the original text from which they were parsed. It also adds a new `IgnoredWhitespace` token to represent whitespace ignored by the parser that was previously thrown out when tokenizing input. Finally, a `render()` method has been added to the `TokenIterator` class, which reproduces the original input text.

This is the first round of changes to address the new features discussed in https://github.com/typesafehub/config/issues/149.