### PR TITLE
Implement non-exploding toString/equals/hashCode on SerializedConfigValu...

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/AbstractConfigValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/AbstractConfigValue.java
@@ -312,7 +312,7 @@ abstract class AbstractConfigValue implements ConfigValue, MergeableValue {
     }
 
     @Override
-    public final String toString() {
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         render(sb, 0, true /* atRoot */, null /* atKey */, ConfigRenderOptions.concise());
         return getClass().getSimpleName() + "(" + sb.toString() + ")";

--- a/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
@@ -497,4 +497,32 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
     protected SerializedConfigValue newCopy(ConfigOrigin origin) {
         throw shouldNotBeUsed();
     }
+
+    @Override
+    public final String toString() {
+        return getClass().getSimpleName() + "(value=" + value + ",wasConfig=" + wasConfig + ")";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // there's no reason we will ever call this equals(), but
+        // the one in AbstractConfigValue would explode due to
+        // calling unwrapped() above, so we just give some
+        // safe-to-call implementation to avoid breaking the
+        // contract of java.lang.Object
+        if (other instanceof SerializedConfigValue) {
+            return canEqual(other)
+                && (this.wasConfig == ((SerializedConfigValue) other).wasConfig)
+                && (this.value.equals(((SerializedConfigValue) other).value));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 41 * (41 + value.hashCode());
+        h = 41 * (h + (wasConfig ? 1 : 0));
+        return h;
+    }
 }


### PR DESCRIPTION
...e

Fixes #176 by ensuring SerializedConfigValue implements the java.lang.Object
contract without exploding. This is a completely internal class, but
-Dsun.io.serialization.extendedDebugInfo=true calls toString on it.