### PR TITLE
Add Config.hasPathOrNull and Config.getIsNull

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ options:
  `Config`; `ConfigObject` implements `java.util.Map<String,?>` and
  the `get()` method on `Map` returns null for missing keys. See
  the API docs for more detail on `Config` vs. `ConfigObject`.
+ 6. Set the setting to `null` in `reference.conf`, then use
+ `Config.getIsNull` and `Config.hasPathOrNull` to handle `null`
+ in a special way while still throwing an exception if the setting
+ is entirely absent.
 
 The *recommended* path (for most cases, in most apps) is that you
 require all settings to be present in either `reference.conf` or

--- a/config/src/main/java/com/typesafe/config/Config.java
+++ b/config/src/main/java/com/typesafe/config/Config.java
@@ -417,6 +417,47 @@ public interface Config extends ConfigMergeable {
     boolean hasPath(String path);
 
     /**
+     * Checks whether a value is present at the given path, even
+     * if the value is null. Most of the getters on
+     * <code>Config</code> will throw if you try to get a null
+     * value, so if you plan to call {@link #getValue(String)},
+     * {@link #getInt(String)}, or another getter you may want to
+     * use plain {@link #hasPath(String)} rather than this method.
+     *
+     * <p>
+     * To handle all three cases (unset, null, and a non-null value)
+     * the code might look like:
+     * <code><pre>
+     * if (config.hasPathOrNull(path)) {
+     *     if (config.getIsNull(path)) {
+     *        // handle null setting
+     *     } else {
+     *        // get and use non-null setting
+     *     }
+     * } else {
+     *     // handle entirely unset path
+     * }
+     * </pre></code>
+     *
+     * <p> However, the usual thing is to allow entirely unset
+     * paths to be a bug that throws an exception (because you set
+     * a default in your <code>reference.conf</code>), so in that
+     * case it's OK to call {@link #getIsNull(String)} without
+     * checking <code>hasPathOrNull</code> first.
+     *
+     * <p>
+     * Note that path expressions have a syntax and sometimes require quoting
+     * (see {@link ConfigUtil#joinPath} and {@link ConfigUtil#splitPath}).
+     *
+     * @param path
+     *            the path expression
+     * @return true if a value is present at the path, even if the value is null
+     * @throws ConfigException.BadPath
+     *             if the path expression is invalid
+     */
+    boolean hasPathOrNull(String path);
+
+    /**
      * Returns true if the {@code Config}'s root object contains no key-value
      * pairs.
      *
@@ -447,6 +488,33 @@ public interface Config extends ConfigMergeable {
      *         each leaf value.
      */
     Set<Map.Entry<String, ConfigValue>> entrySet();
+
+    /**
+     * Checks whether a value is set to null at the given path,
+     * but throws an exception if the value is entirely
+     * unset. This method will not throw if {@link
+     * #hasPathOrNull(String)} returned true for the same path, so
+     * to avoid any possible exception check
+     * <code>hasPathOrNull()</code> first.  However, an exception
+     * for unset paths will usually be the right thing (because a
+     * <code>reference.conf</code> should exist that has the path
+     * set, the path should never be unset unless something is
+     * broken).
+     *
+     * <p>
+     * Note that path expressions have a syntax and sometimes require quoting
+     * (see {@link ConfigUtil#joinPath} and {@link ConfigUtil#splitPath}).
+     *
+     * @param path
+     *            the path expression
+     * @return true if the value exists and is null, false if it
+     * exists and is not null
+     * @throws ConfigException.BadPath
+     *             if the path expression is invalid
+     * @throws ConfigException.Missing
+     *             if value is not set at all
+     */
+    boolean getIsNull(String path);
 
     /**
      *

--- a/config/src/main/java/com/typesafe/config/Config.java
+++ b/config/src/main/java/com/typesafe/config/Config.java
@@ -427,7 +427,7 @@ public interface Config extends ConfigMergeable {
      * <p>
      * To handle all three cases (unset, null, and a non-null value)
      * the code might look like:
-     * <code><pre>
+     * <pre><code>
      * if (config.hasPathOrNull(path)) {
      *     if (config.getIsNull(path)) {
      *        // handle null setting
@@ -437,7 +437,7 @@ public interface Config extends ConfigMergeable {
      * } else {
      *     // handle entirely unset path
      * }
-     * </pre></code>
+     * </code></pre>
      *
      * <p> However, the usual thing is to allow entirely unset
      * paths to be a bug that throws an exception (because you set

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -1057,4 +1057,38 @@ include "onclasspath"
         assertFalse("did not get bar-file.conf", conf.hasPath("bar-file"))
         assertFalse("did not get subdir/baz.conf", conf.hasPath("baz"))
     }
+
+    @Test
+    def hasPathOrNullWorks(): Unit = {
+        val conf = ConfigFactory.parseString("x.a=null,x.b=42")
+        assertFalse("hasPath says false for null", conf.hasPath("x.a"))
+        assertTrue("hasPathOrNull says true for null", conf.hasPathOrNull("x.a"))
+
+        assertTrue("hasPath says true for non-null", conf.hasPath("x.b"))
+        assertTrue("hasPathOrNull says true for non-null", conf.hasPathOrNull("x.b"))
+
+        assertFalse("hasPath says false for missing", conf.hasPath("x.c"))
+        assertFalse("hasPathOrNull says false for missing", conf.hasPathOrNull("x.c"))
+
+        // this is to be sure we handle a null along the path correctly
+        assertFalse("hasPath says false for missing under null", conf.hasPath("x.a.y"))
+        assertFalse("hasPathOrNull says false for missing under null", conf.hasPathOrNull("x.a.y"))
+
+        // this is to be sure we handle missing along the path correctly
+        assertFalse("hasPath says false for missing under missing", conf.hasPath("x.c.y"))
+        assertFalse("hasPathOrNull says false for missing under missing", conf.hasPathOrNull("x.c.y"))
+    }
+
+    @Test
+    def getIsNullWorks(): Unit = {
+        val conf = ConfigFactory.parseString("x.a=null,x.b=42")
+
+        assertTrue("getIsNull says true for null", conf.getIsNull("x.a"))
+        assertFalse("getIsNull says false for non-null", conf.getIsNull("x.b"))
+        intercept[ConfigException.Missing] { conf.getIsNull("x.c") }
+        // missing underneath null
+        intercept[ConfigException.Missing] { conf.getIsNull("x.a.y") }
+        // missing underneath missing
+        intercept[ConfigException.Missing] { conf.getIsNull("x.c.y") }
+    }
 }


### PR DESCRIPTION
This is for #186 / #282 as an alternative to adding
a ton of getFooOrNull methods. With these methods apps
can handle null or missing settings in a special way
if they see fit.