### PR TITLE
Add some failing tests for ConfigDocument.removeValue

### DIFF
--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -227,6 +227,30 @@ class ConfigDocumentTest extends TestUtils {
     }
 
     @Test
+    def configDocumentRemoveMultiple {
+        val origText = "a { b: 42 }, a.b = 43, a { b: { c: 44 } }"
+        val configDoc = ConfigDocumentFactory.parseString(origText)
+        val removed = configDoc.removeValue("a.b")
+        assertEquals("a { }, a { b: { } }", removed.render())
+    }
+
+    @Test
+    def configDocumentRemoveOverridden {
+        val origText = "a { b: 42 }, a.b = 43, a { b: { c: 44 }, a : 57 }"
+        val configDoc = ConfigDocumentFactory.parseString(origText)
+        val removed = configDoc.removeValue("a.b")
+        assertEquals("a { }, a : 57", removed.render())
+    }
+
+    @Test
+    def configDocumentRemoveNested {
+        val origText = "a { b: 42 }, a.b = 43, a { b: { c: 44 } }"
+        val configDoc = ConfigDocumentFactory.parseString(origText)
+        val removed = configDoc.removeValue("a.b.c")
+        assertEquals("a { b: 42 }, a.b = 43, a { b: {  } }", removed.render())
+    }
+
+    @Test
     def configDocumentArrayFailures {
         // Attempting a replace on a ConfigDocument parsed from an array throws an error
         val origText = "[1, 2, 3, 4, 5]"


### PR DESCRIPTION
@fpringvaldsen I thought I'd quickly check out some corner cases here. I'm not sure my "correct" results are exactly right (there are several reasonable results here) but it's definitely wrong to remove `a.b=42` by replacing it with just `a`, for example.

A question is whether, when we remove `a.b=42`, we should remove any objects along that path that become empty. That is, do we delete the whole line or do we make it into `a={}`? In any case we shouldn't make it into just `a`. The same basic question arises when using the more verbose syntax, that is, if we have `a : { b : 42 }` and remove `a.b`, do we leave `a : {}` or do we remove the entire thing?

Comments / want to take a crack at a fix?