### PR TITLE
Update/cleanup ConfigNodeTests

### DIFF
--- a/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
@@ -5,8 +5,8 @@ import org.junit.Test
 
 class ConfigNodeTest extends TestUtils {
 
-    private def basicNodeTest(token: Token) {
-        val node = configNodeBasic(token);
+    private def singleTokenNodeTest(token: Token) {
+        val node = configNodeSingleToken(token);
         assertEquals(node.render(), token.tokenText())
     }
 
@@ -20,25 +20,25 @@ class ConfigNodeTest extends TestUtils {
         assertEquals(node.render(), token.tokenText())
     }
 
-    private def fieldNodeTest(key: ConfigNodePath, value: AbstractConfigNodeValue, trailingWhitespace: ConfigNodeSingleToken, newValue: AbstractConfigNodeValue) {
-        val keyValNode = nodeKeyValuePair(key, value, trailingWhitespace)
-        assertEquals(key.render() + " : " + value.render() + trailingWhitespace.render(), keyValNode.render())
+    private def fieldNodeTest(key: ConfigNodePath, value: AbstractConfigNodeValue, newValue: AbstractConfigNodeValue) {
+        val keyValNode = nodeKeyValuePair(key, value)
+        assertEquals(key.render() + " : " + value.render(), keyValNode.render())
         assertEquals(key.render, keyValNode.path().render())
         assertEquals(value.render, keyValNode.value().render())
 
         val newKeyValNode = keyValNode.replaceValue(newValue)
-        assertEquals(key.render() + " : " + newValue.render() + trailingWhitespace.render(), newKeyValNode.render())
+        assertEquals(key.render() + " : " + newValue.render(), newKeyValNode.render())
         assertEquals(newValue.render(), newKeyValNode.value().render())
     }
 
     private def topLevelValueReplaceTest(value: AbstractConfigNodeValue, newValue: AbstractConfigNodeValue, key: String = "foo") {
         val complexNodeChildren = List(nodeOpenBrace,
-            nodeKeyValuePair(nodeWhitespace("       "), configNodeKey(key), value, nodeWhitespace("    ")),
+            nodeKeyValuePair(configNodeKey(key), value),
             nodeCloseBrace)
         val complexNode = configNodeObject(complexNodeChildren)
         val newNode = complexNode.setValueOnPath(key, newValue)
-        val origText = "{       " + key + " : " + value.render() + "    }"
-        val finalText = "{       " + key + " : " + newValue.render() + "    }"
+        val origText = "{" + key + " : " + value.render() + "}"
+        val finalText = "{" + key + " : " + newValue.render() + "}"
 
         assertEquals(origText, complexNode.render())
         assertEquals(finalText, newNode.render())
@@ -67,22 +67,22 @@ class ConfigNodeTest extends TestUtils {
 
     @Test
     def createBasicConfigNode() {
-        //Ensure a BasicConfigNode can handle all its required token types
-        basicNodeTest(Tokens.START)
-        basicNodeTest(Tokens.END)
-        basicNodeTest(Tokens.OPEN_CURLY)
-        basicNodeTest(Tokens.CLOSE_CURLY)
-        basicNodeTest(Tokens.OPEN_SQUARE)
-        basicNodeTest(Tokens.CLOSE_SQUARE)
-        basicNodeTest(Tokens.COMMA)
-        basicNodeTest(Tokens.EQUALS)
-        basicNodeTest(Tokens.COLON)
-        basicNodeTest(Tokens.PLUS_EQUALS)
-        basicNodeTest(tokenUnquoted("             "))
-        basicNodeTest(tokenWhitespace("             "))
-        basicNodeTest(tokenLine(1))
-        basicNodeTest(tokenCommentDoubleSlash("  this is a double slash comment   "))
-        basicNodeTest(tokenCommentHash("   this is a hash comment   "))
+        //Ensure a ConfigNodeSingleToken can handle all its required token types
+        singleTokenNodeTest(Tokens.START)
+        singleTokenNodeTest(Tokens.END)
+        singleTokenNodeTest(Tokens.OPEN_CURLY)
+        singleTokenNodeTest(Tokens.CLOSE_CURLY)
+        singleTokenNodeTest(Tokens.OPEN_SQUARE)
+        singleTokenNodeTest(Tokens.CLOSE_SQUARE)
+        singleTokenNodeTest(Tokens.COMMA)
+        singleTokenNodeTest(Tokens.EQUALS)
+        singleTokenNodeTest(Tokens.COLON)
+        singleTokenNodeTest(Tokens.PLUS_EQUALS)
+        singleTokenNodeTest(tokenUnquoted("             "))
+        singleTokenNodeTest(tokenWhitespace("             "))
+        singleTokenNodeTest(tokenLine(1))
+        singleTokenNodeTest(tokenCommentDoubleSlash("  this is a double slash comment   "))
+        singleTokenNodeTest(tokenCommentHash("   this is a hash comment   "))
     }
 
     @Test
@@ -120,12 +120,12 @@ class ConfigNodeTest extends TestUtils {
     @Test
     def createConfigNodeField() {
         // Supports Quoted and Unquoted keys
-        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), nodeLine(1), nodeInt(245))
-        fieldNodeTest(configNodeKey("abc"), nodeInt(123), nodeLine(1), nodeInt(245))
+        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), nodeInt(245))
+        fieldNodeTest(configNodeKey("abc"), nodeInt(123), nodeInt(245))
 
         // Can replace value with values of different types
-        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), nodeLine(1), nodeString("I am a string"))
-        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), nodeLine(1), configNodeObject(List(nodeOpenBrace, nodeCloseBrace)))
+        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), nodeString("I am a string"))
+        fieldNodeTest(configNodeKey("\"abc\""), nodeInt(123), configNodeObject(List(nodeOpenBrace, nodeCloseBrace)))
     }
 
     @Test
@@ -149,9 +149,9 @@ class ConfigNodeTest extends TestUtils {
         topLevelValueReplaceTest(array, nodeInt(10))
         topLevelValueReplaceTest(array, configNodeObject(List(nodeOpenBrace, nodeCloseBrace)))
 
-        // Ensure maps can be replaced
-        val nestedMap = configNodeObject(List(nodeOpenBrace, configNodeKey("abc"),
-            nodeColon, configNodeSimpleValue(tokenString("a string")),
+        // Ensure objects can be replaced
+        val nestedMap = configNodeObject(List(nodeOpenBrace,
+            nodeKeyValuePair(configNodeKey("abc"), configNodeSimpleValue(tokenString("a string"))),
             nodeCloseBrace))
         topLevelValueReplaceTest(nestedMap, nodeInt(10))
         topLevelValueReplaceTest(nodeInt(10), nestedMap)
@@ -187,7 +187,7 @@ class ConfigNodeTest extends TestUtils {
     def addNonExistentPaths() {
         nonExistentPathTest(nodeInt(10))
         nonExistentPathTest(configNodeArray(List(nodeOpenBracket, nodeInt(15), nodeCloseBracket)))
-        nonExistentPathTest(configNodeObject(List(nodeOpenBrace, nodeKeyValuePair(configNodeKey("foo"), nodeDouble(3.14), nodeSpace))))
+        nonExistentPathTest(configNodeObject(List(nodeOpenBrace, nodeKeyValuePair(configNodeKey("foo"), nodeDouble(3.14)), nodeCloseBrace)))
     }
 
     @Test
@@ -201,11 +201,11 @@ class ConfigNodeTest extends TestUtils {
             nodeWhitespace("\t"), nodeCloseBrace))
         val higherLevelMap = configNodeObject(List(nodeOpenBrace, nodeLine(2),
             nodeWhitespace("\t"), nodeKeyValuePair(configNodeKey("\"abc.def\""), configNodeSimpleValue(tokenInt(123))), nodeLine(3),
-            nodeWhitespace("\t"), configNodeBasic(tokenCommentDoubleSlash("This is a comment about the below setting")),
+            nodeWhitespace("\t"), nodeCommentDoubleSlash(("This is a comment about the below setting")),
             nodeLine(4), nodeLine(5),
-            nodeWhitespace("\t"), nodeKeyValuePair(configNodeKey("abc"), lowestLevelMap), nodeLine(9), nodeWhitespace(""),
+            nodeWhitespace("\t"), nodeKeyValuePair(configNodeKey("abc"), lowestLevelMap), nodeLine(9),
             nodeCloseBrace))
-        val origNode = configNodeObject(List(nodeKeyValuePair(configNodeKey("foo"), configNodeSimpleValue(tokenUnquoted("bar")), nodeLine(1)),
+        val origNode = configNodeObject(List(nodeKeyValuePair(configNodeKey("foo"), configNodeSimpleValue(tokenUnquoted("bar"))), nodeLine(1),
             nodeKeyValuePair(configNodeKey("baz"), higherLevelMap), nodeLine(10),
             nodeKeyValuePair(configNodeKey("baz.abc.ghi"), configNodeSimpleValue(tokenInt(52))), nodeLine(11),
             nodeKeyValuePair(configNodeKey("baz.abc.ghi"), configNodeSimpleValue(tokenInt(53))), nodeLine(12),

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -669,7 +669,7 @@ abstract trait TestUtils {
 
     def configNodeKey(path: String) = PathParser.parsePathNode(path)
 
-    def configNodeBasic(value: Token) = {
+    def configNodeSingleToken(value: Token) = {
         new ConfigNodeSingleToken(value: Token)
     }
 
@@ -698,22 +698,14 @@ abstract trait TestUtils {
         val nodes = List(key, nodeSpace, nodeColon, nodeSpace, value)
         new ConfigNodeField(nodes.asJavaCollection)
     }
-    def nodeKeyValuePair(key: ConfigNodePath, value: AbstractConfigNodeValue, trailingWhitespace: ConfigNodeSingleToken) = {
-        val nodes = List(key, nodeSpace, nodeColon, nodeSpace, value, trailingWhitespace)
-        new ConfigNodeField(nodes.asJavaCollection)
-    }
-    def nodeKeyValuePair(leadingWhitespace: ConfigNodeSingleToken, key: ConfigNodePath, value: AbstractConfigNodeValue, trailingWhitespace: ConfigNodeSingleToken) = {
-        val nodes = List(leadingWhitespace, key, nodeSpace, nodeColon, nodeSpace, value, trailingWhitespace)
-        new ConfigNodeField(nodes.asJavaCollection)
-    }
     def nodeInt(value: Integer) = new ConfigNodeSimpleValue(tokenInt(value))
     def nodeString(value: String) = new ConfigNodeSimpleValue(tokenString(value))
     def nodeLong(value: Long) = new ConfigNodeSimpleValue(tokenLong(value))
     def nodeDouble(value: Double) = new ConfigNodeSimpleValue(tokenDouble(value))
     def nodeTrue = new ConfigNodeSimpleValue(tokenTrue)
     def nodeFalse = new ConfigNodeSimpleValue(tokenFalse)
-    def nodeCommentHash(text: String) = new ConfigNodeSingleToken(tokenCommentHash(text))
-    def nodeCommentDoubleSlash(text: String) = new ConfigNodeSingleToken(tokenCommentDoubleSlash(text))
+    def nodeCommentHash(text: String) = new ConfigNodeComment(tokenCommentHash(text))
+    def nodeCommentDoubleSlash(text: String) = new ConfigNodeComment(tokenCommentDoubleSlash(text))
     def nodeUnquotedText(text: String) = new ConfigNodeSimpleValue(tokenUnquoted(text))
     def nodeNull = new ConfigNodeSimpleValue(tokenNull)
     def nodeKeySubstitution(s: String) = new ConfigNodeSimpleValue(tokenKeySubstitution(s))


### PR DESCRIPTION
I was going through the ConfigNode tests and discovered some inconsistencies due to a number of changes made to the way various ConfigNode classes work. In particular, I removed all leading/trailing whitespace from `ConfigNodeField`s as that is the responsibility of parent nodes, and I changed the representation of tokens to use `ConfigNodeComment` instead of `ConfigNodeSingleToken`.