### PR TITLE
Rename ConfigDocument methods for consistency

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
@@ -629,7 +629,7 @@ final class ConfigDocumentParser {
 
             t = nextToken();
             if (Tokens.isIgnoredWhitespace(t) || Tokens.isNewline(t) || isUnquotedWhitespace(t) || Tokens.isComment(t)) {
-                throw parseError("The value from setValue cannot have leading or trailing newlines, whitespace, or comments");
+                throw parseError("The value from withValueText cannot have leading or trailing newlines, whitespace, or comments");
             }
             if (t == Tokens.END) {
                 throw parseError("Empty value");
@@ -640,7 +640,7 @@ final class ConfigDocumentParser {
                 if (t == Tokens.END) {
                     return node;
                 } else {
-                    throw parseError("Parsing JSON and the value set in setValue was either a concatenation or " +
+                    throw parseError("Parsing JSON and the value set in withValueText was either a concatenation or " +
                                         "had trailing whitespace, newlines, or comments");
                 }
             } else {
@@ -651,7 +651,7 @@ final class ConfigDocumentParser {
                 if (t == Tokens.END) {
                     return node;
                 } else {
-                    throw parseError("The value from setValue cannot have leading or trailing newlines, whitespace, or comments");
+                    throw parseError("The value from withValueText cannot have leading or trailing newlines, whitespace, or comments");
                 }
             }
         }

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
@@ -3,6 +3,7 @@ package com.typesafe.config.impl;
 import com.typesafe.config.parser.ConfigDocument;
 import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigException;
 
 import java.io.StringReader;
 import java.util.Iterator;
@@ -16,7 +17,10 @@ final class SimpleConfigDocument implements ConfigDocument {
         this.parseOptions = parseOptions;
     }
 
-    public ConfigDocument setValue(String path, String newValue) {
+    @Override
+    public ConfigDocument withValueText(String path, String newValue) {
+        if (newValue == null)
+            throw new ConfigException.BugOrBroken("null value for " + path + " passed to withValueText");
         SimpleConfigOrigin origin = SimpleConfigOrigin.newSimple("single value parsing");
         StringReader reader = new StringReader(newValue);
         Iterator<Token> tokens = Tokenizer.tokenize(origin, reader, parseOptions.getSyntax());
@@ -26,15 +30,20 @@ final class SimpleConfigDocument implements ConfigDocument {
         return new SimpleConfigDocument(configNodeTree.setValue(path, parsedValue, parseOptions.getSyntax()), parseOptions);
     }
 
-    public ConfigDocument setValue(String path, ConfigValue newValue) {
-        return setValue(path, newValue.render().trim());
+    @Override
+    public ConfigDocument withValue(String path, ConfigValue newValue) {
+        if (newValue == null)
+            throw new ConfigException.BugOrBroken("null value for " + path + " passed to withValue");
+        return withValueText(path, newValue.render().trim());
     }
 
-    public ConfigDocument removeValue(String path) {
+    @Override
+    public ConfigDocument withoutPath(String path) {
         return new SimpleConfigDocument(configNodeTree.setValue(path, null, parseOptions.getSyntax()), parseOptions);
     }
 
-    public boolean hasValue(String path) {
+    @Override
+    public boolean hasPath(String path) {
         return configNodeTree.hasValue(path);
     }
 

--- a/config/src/main/java/com/typesafe/config/parser/ConfigDocument.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigDocument.java
@@ -38,11 +38,12 @@ public interface ConfigDocument {
      *                 into the ConfigDocument.
      * @return a copy of the ConfigDocument with the desired value at the desired path
      */
-    ConfigDocument setValue(String path, String newValue);
+    ConfigDocument withValueText(String path, String newValue);
 
     /**
-     * Returns a new ConfigDocument that is a copy of the current ConfigDocument,
-     * but with the desired value set at the desired path as with {@link #setValue(String, String)},
+     * Returns a new ConfigDocument that is a copy of the current
+     * ConfigDocument, but with the desired value set at the
+     * desired path. Works like {@link #withValueText(String, String)},
      * but takes a ConfigValue instead of a string.
      *
      * @param path the path at which to set the desired value
@@ -51,25 +52,26 @@ public interface ConfigDocument {
      *                 ConfigDocument.
      * @return a copy of the ConfigDocument with the desired value at the desired path
      */
-    ConfigDocument setValue(String path, ConfigValue newValue);
+    ConfigDocument withValue(String path, ConfigValue newValue);
 
     /**
      * Returns a new ConfigDocument that is a copy of the current ConfigDocument, but with
-     * the value at the desired path removed. If the desired path does not exist in the document,
+     * all values at the desired path removed. If the path does not exist in the document,
      * a copy of the current document will be returned. If there is an array at the root, an exception
      * will be thrown.
      *
      * @param path the path to remove from the document
      * @return a copy of the ConfigDocument with the desired value removed from the document.
      */
-    ConfigDocument removeValue(String path);
+    ConfigDocument withoutPath(String path);
 
     /**
      * Returns a boolean indicating whether or not a ConfigDocument has a value at the desired path.
+     * null counts as a value for purposes of this check.
      * @param path the path to check
      * @return true if the path exists in the document, otherwise false
      */
-    boolean hasValue(String path);
+    boolean hasPath(String path);
 
     /**
      * The original text of the input, modified if necessary with

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
@@ -54,7 +54,7 @@ class ConfigDocumentParserTest extends TestUtils {
         val e = intercept[ConfigException] {
             ConfigDocumentParser.parseValue(tokenize(toReplace), fakeOrigin(), ConfigParseOptions.defaults())
         }
-        assertTrue(e.getMessage.contains("The value from setValue cannot have leading or trailing newlines, whitespace, or comments"))
+        assertTrue("expected message parsing leading trailing", e.getMessage.contains("The value from withValueText cannot have leading or trailing newlines, whitespace, or comments"))
     }
 
     @Test
@@ -268,12 +268,12 @@ class ConfigDocumentParserTest extends TestUtils {
         // Check that concatenations in JSON will throw an error
         var origText = "123 456 \"abc\""
         var e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON)) }
-        assertTrue(e.getMessage.contains("Parsing JSON and the value set in setValue was either a concatenation or had trailing whitespace, newlines, or comments"))
+        assertTrue("expected message for parsing concat as json", e.getMessage.contains("Parsing JSON and the value set in withValueText was either a concatenation or had trailing whitespace, newlines, or comments"))
 
         // Check that keys with no separators and object values in JSON will throw an error
         origText = """{"foo" { "bar" : 12 } }"""
         e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax((ConfigSyntax.JSON))) }
-        assertTrue(e.getMessage.contains("""Key '"foo"' may not be followed by token: '{'"""))
+        assertTrue("expected failure for key foo followed by token", e.getMessage.contains("""Key '"foo"' may not be followed by token: '{'"""))
     }
 
     @Test


### PR DESCRIPTION
 * withValue, withoutPath, hasPath now match Config methods
 * withValueText replaces setValue(String,String)

Closes #303