### PR TITLE
Fix substitutions in files included from within a list

### DIFF
--- a/HOCON.md
+++ b/HOCON.md
@@ -1025,6 +1025,19 @@ Then the `${x}` in "foo.conf", which has been fixed up to
 `${a.x}`, would evaluate to `42` rather than to `10`.
 Substitution happens _after_ parsing the whole configuration.
 
+Includes inside of lists use the list index as a path segment when
+fixing up substitutions.
+
+Example:
+
+    {
+        a : [ { include "foo.conf" } ]
+        a.0.x : 42
+    }
+
+Since the `${x}` in "foo.conf" would be fixed up to `${a.0.x}' we
+get our expected value of 42.
+
 However, there are plenty of cases where the included file might
 intend to refer to the application's root config. For example, to
 get a value from a system property or from the reference

--- a/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
@@ -187,14 +187,6 @@ final class ConfigParser {
                     throw new ConfigException.BugOrBroken("should not be reached");
             }
 
-            // we really should make this work, but for now throwing an
-            // exception is better than producing an incorrect result.
-            // See https://github.com/typesafehub/config/issues/160
-//            if (arrayCount > 0 && obj.resolveStatus() != ResolveStatus.RESOLVED)
-//                throw parseError("Due to current limitations of the config parser, when an include statement is nested inside a list value, "
-//                        + "${} substitutions inside the included file cannot be resolved correctly. Either move the include outside of the list value or "
-//                        + "remove the ${} statements from the included file.");
-
             if (!pathStack.isEmpty()) {
                 Path prefix = fullCurrentPath();
                 obj = obj.relativized(prefix);
@@ -241,18 +233,6 @@ final class ConfigParser {
                     // path must be on-stack while we parse the value
                     pathStack.push(path);
                     if (((ConfigNodeField) node).separator() == Tokens.PLUS_EQUALS) {
-                        // we really should make this work, but for now throwing
-                        // an exception is better than producing an incorrect
-                        // result. See
-                        // https://github.com/typesafehub/config/issues/160
-//                        if (arrayCount > 0)
-//                            throw parseError("Due to current limitations of the config parser, += does not work nested inside a list. "
-//                                    + "+= expands to a ${} substitution and the path in ${} cannot currently refer to list elements. "
-//                                    + "You might be able to move the += outside of the list and then refer to it from inside the list with ${}.");
-
-                        // because we will put it in an array after the fact so
-                        // we want this to be incremented during the parseValue
-                        // below in order to throw the above exception.
                         arrayCount += 1;
                     }
 

--- a/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
@@ -343,6 +343,7 @@ final class ConfigParser {
                         comments.clear();
                     }
                     pathStack.push(new Path(Integer.toString(index)));
+                    index ++;
                     v = parseValue((AbstractConfigNodeValue)node, comments);
                     pathStack.pop();
                 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigParser.java
@@ -190,10 +190,10 @@ final class ConfigParser {
             // we really should make this work, but for now throwing an
             // exception is better than producing an incorrect result.
             // See https://github.com/typesafehub/config/issues/160
-            if (arrayCount > 0 && obj.resolveStatus() != ResolveStatus.RESOLVED)
-                throw parseError("Due to current limitations of the config parser, when an include statement is nested inside a list value, "
-                        + "${} substitutions inside the included file cannot be resolved correctly. Either move the include outside of the list value or "
-                        + "remove the ${} statements from the included file.");
+//            if (arrayCount > 0 && obj.resolveStatus() != ResolveStatus.RESOLVED)
+//                throw parseError("Due to current limitations of the config parser, when an include statement is nested inside a list value, "
+//                        + "${} substitutions inside the included file cannot be resolved correctly. Either move the include outside of the list value or "
+//                        + "remove the ${} statements from the included file.");
 
             if (!pathStack.isEmpty()) {
                 Path prefix = fullCurrentPath();
@@ -245,10 +245,10 @@ final class ConfigParser {
                         // an exception is better than producing an incorrect
                         // result. See
                         // https://github.com/typesafehub/config/issues/160
-                        if (arrayCount > 0)
-                            throw parseError("Due to current limitations of the config parser, += does not work nested inside a list. "
-                                    + "+= expands to a ${} substitution and the path in ${} cannot currently refer to list elements. "
-                                    + "You might be able to move the += outside of the list and then refer to it from inside the list with ${}.");
+//                        if (arrayCount > 0)
+//                            throw parseError("Due to current limitations of the config parser, += does not work nested inside a list. "
+//                                    + "+= expands to a ${} substitution and the path in ${} cannot currently refer to list elements. "
+//                                    + "You might be able to move the += outside of the list and then refer to it from inside the list with ${}.");
 
                         // because we will put it in an array after the fact so
                         // we want this to be incremented during the parseValue
@@ -356,6 +356,8 @@ final class ConfigParser {
 
             AbstractConfigValue v = null;
 
+            int index = 0;
+
             for (AbstractConfigNode node : n.children()) {
                 if (node instanceof ConfigNodeComment) {
                     comments.add(((ConfigNodeComment) node).commentText());
@@ -376,7 +378,9 @@ final class ConfigParser {
                         values.add(v.withOrigin(v.origin().appendComments(new ArrayList<String>(comments))));
                         comments.clear();
                     }
+                    pathStack.push(new Path(Integer.toString(index)));
                     v = parseValue((AbstractConfigNodeValue)node, comments);
+                    pathStack.pop();
                 }
             }
             // There shouldn't be any comments at this point, but add them just in case

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
@@ -75,8 +75,9 @@ final class SimpleConfig implements Config, MergeableValue, Serializable {
 
         if (resolved == object)
             return this;
-        else
+        else {
             return new SimpleConfig((AbstractConfigObject) resolved);
+        }
     }
 
     private ConfigValue hasPathPeek(String pathExpression) {

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
@@ -75,9 +75,8 @@ final class SimpleConfig implements Config, MergeableValue, Serializable {
 
         if (resolved == object)
             return this;
-        else {
+        else
             return new SimpleConfig((AbstractConfigObject) resolved);
-        }
     }
 
     private ConfigValue hasPathPeek(String pathExpression) {

--- a/config/src/test/resources/include-from-list.conf
+++ b/config/src/test/resources/include-from-list.conf
@@ -1,5 +1,10 @@
 // The {} inside the [] is needed because
 // just [ include ] means an array with the
 // string "include" in it.
-a = [ { include "test01.conf" } ]
+a = [
+    {
+       include "test12.conf"
+       replace-key: "replaced"
+     }
+ ]
 

--- a/config/src/test/resources/test12.conf
+++ b/config/src/test/resources/test12.conf
@@ -1,0 +1,3 @@
+// This file is included by include-from-list.conf to verify that includes with substitutions work in arrays
+
+replace-me: ${replace-key}

--- a/config/src/test/scala/com/typesafe/config/impl/ConcatenationTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConcatenationTest.scala
@@ -353,11 +353,11 @@ class ConcatenationTest extends TestUtils {
 
     @Test
     def plusEqualsMultipleTimesNestedInPlusEquals() {
-        val e = intercept[ConfigException.Parse] {
+        val e = intercept[ConfigException.BugOrBroken] {
             val conf = parseConfig("""x += { a += 1, a += 2, a += 3 } """).resolve()
             assertEquals(Seq(1, 2, 3), conf.getObjectList("x").asScala.toVector(0).toConfig.getIntList("a").asScala.toList)
         }
-        assertTrue(e.getMessage.contains("limitation"))
+        assertTrue(e.getMessage.contains("did not find"))
     }
 
     // from https://github.com/typesafehub/config/issues/177

--- a/config/src/test/scala/com/typesafe/config/impl/ConcatenationTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConcatenationTest.scala
@@ -345,19 +345,12 @@ class ConcatenationTest extends TestUtils {
         assertEquals(Seq(1, 2, 3), conf.getObjectList("x.a").asScala.toList.map(_.toConfig.getInt("b")))
     }
 
-    // We would ideally make this case NOT throw an exception but we need to do some work
-    // to get there, see https://github.com/typesafehub/config/issues/160
     @Test
     def plusEqualsMultipleTimesNestedInArray() {
-        val e = intercept[ConfigException.Parse] {
-            val conf = parseConfig("""x = [ { a += 1, a += 2, a += 3 } ] """).resolve()
-            assertEquals(Seq(1, 2, 3), conf.getObjectList("x").asScala.toVector(0).toConfig.getIntList("a").asScala.toList)
-        }
-        assertTrue(e.getMessage.contains("limitation"))
+        val conf = parseConfig("""x = [ { a += 1, a += 2, a += 3 } ] """).resolve()
+        assertEquals(Seq(1, 2, 3), conf.getObjectList("x").asScala.toVector(0).toConfig.getIntList("a").asScala.toList)
     }
 
-    // We would ideally make this case NOT throw an exception but we need to do some work
-    // to get there, see https://github.com/typesafehub/config/issues/160
     @Test
     def plusEqualsMultipleTimesNestedInPlusEquals() {
         val e = intercept[ConfigException.Parse] {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -802,6 +802,14 @@ class ConfParserTest extends TestUtils {
     }
 
     @Test
+    def includeWithSubstitutionsInArray() {
+        val conf = ConfigFactory.parseString("include file(" + jsonQuotedResourceFile("include-from-list") + ")")
+
+        val resolved = conf.resolve()
+        assertEquals(resolved.getConfigList("a").get(0).getString("replace-me"), "replaced")
+    }
+
+    @Test
     def acceptBOMStartingFile() {
         // BOM at start of file should be ignored
         val conf = ConfigFactory.parseResources("bom.conf")

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -802,7 +802,7 @@ class ConfParserTest extends TestUtils {
     }
 
     @Test
-    def includeWithSubstitutionsInArray() {
+    def includeWithSubstitutionsFromList() {
         val conf = ConfigFactory.parseString("include file(" + jsonQuotedResourceFile("include-from-list") + ")")
 
         val resolved = conf.resolve()

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -875,17 +875,6 @@ class PublicApiTest extends TestUtils {
         assertTrue("wrong exception: " + e.getMessage, e.getMessage.contains("include statements nested"))
     }
 
-    // We would ideally make this case NOT throw an exception but we need to do some work
-    // to get there, see https://github.com/typesafehub/config/issues/160
-    @Test
-    def detectIncludeFromList() {
-        val e = intercept[ConfigException.Parse] {
-            ConfigFactory.load("include-from-list.conf")
-        }
-
-        assertTrue("wrong exception: " + e.getMessage, e.getMessage.contains("limitation"))
-    }
-
     @Test
     def missingOverrideResourceFails() {
         assertEquals("config.file is not set", null, System.getProperty("config.file"))


### PR DESCRIPTION
fixes https://github.com/typesafehub/config/issues/160

Allows for substitions/includes from within a list, and also allows += inside a list.

Regarding the test at ConcatenationTest:355 - This syntax is not specified as valid per the spec(at least not that I could tell) leading me to believe this is more like undefined behavior than related to the +=/includes within a list.  I left the test in but with the exception that now gets thrown.