### PR TITLE
Fix single-line config bug

### DIFF
--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -171,14 +171,14 @@ class ConfigDocumentTest extends TestUtils {
     @Test
     def configDocumentSetNewValueMultiLevelConf {
         val origText = "a:b\nc:d"
-        val finalText = "a:b\nc:d\ne : { f : { g : 12 } }"
+        val finalText = "a:b\nc:d\ne : {\n  f : {\n    g : 12\n  }\n}"
         configDocumentReplaceConfTest(origText, finalText, "12", "e.f.g")
     }
 
     @Test
     def configDocumentSetNewValueMultiLevelJson {
         val origText = "{\"a\":\"b\",\n\"c\":\"d\"}"
-        val finalText = "{\"a\":\"b\",\n\"c\":\"d\",\n\"e\" : { \"f\" : { \"g\" : 12 } }}"
+        val finalText = "{\"a\":\"b\",\n\"c\":\"d\",\n  \"e\" : {\n    \"f\" : {\n      \"g\" : 12\n    }\n  }}"
         configDocumentReplaceJsonTest(origText, finalText, "12", "e.f.g")
     }
 
@@ -342,13 +342,13 @@ class ConfigDocumentTest extends TestUtils {
         var configDocument = ConfigDocumentFactory.parseString(origText)
         assertEquals("a {\n  b: c\n  e : f\n}", configDocument.withValueText("a.e", "f").render())
 
-        assertEquals("a {\n  b: c\n  d : { e : { f : g } }\n}", configDocument.withValueText("a.d.e.f", "g").render())
+        assertEquals("a {\n  b: c\n  d : {\n    e : {\n      f : g\n    }\n  }\n}", configDocument.withValueText("a.d.e.f", "g").render())
 
         origText = "a {\n b: c\n}\n"
         configDocument = ConfigDocumentFactory.parseString(origText)
         assertEquals("a {\n b: c\n}\nd : e\n", configDocument.withValueText("d", "e").render())
 
-        assertEquals("a {\n b: c\n}\nd : { e : { f : g } }\n", configDocument.withValueText("d.e.f", "g").render())
+        assertEquals("a {\n b: c\n}\nd : {\n  e : {\n    f : g\n  }\n}\n", configDocument.withValueText("d.e.f", "g").render())
     }
 
     @Test
@@ -435,7 +435,7 @@ class ConfigDocumentTest extends TestUtils {
         val origText = ""
         val configDocument = ConfigDocumentFactory.parseString(origText)
 
-        assertEquals(" a : 1", configDocument.withValueText("a", "1").render)
+        assertEquals("a : 1", configDocument.withValueText("a", "1").render)
     }
 
     @Test
@@ -447,7 +447,5 @@ class ConfigDocumentTest extends TestUtils {
 
         assertEquals("{ a : {\n     # hardcoded value\n     \"a\" : 1,\n     # hardcoded value\n     \"b\" : 2\n } }",
             configDocument.withValue("a", configVal).render)
-
     }
-
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
@@ -212,7 +212,7 @@ class ConfigNodeTest extends TestUtils {
             nodeCloseBrace))
         assertEquals(origText, origNode.render())
         val finalText = "foo : bar\nbaz : {\n\t\"abc.def\" : true\n\t//This is a comment about the below setting\n\n\tabc : {\n\t\t" +
-            "def : false\n\t\t\n\t\t\"this.does.not.exist@@@+$#\" : { end : doesnotexist }\n\t}\n}\n\nbaz.abc.ghi : randomunquotedString\n}"
+            "def : false\n\t\t\n\t\t\"this.does.not.exist@@@+$#\" : {\n\t\t  end : doesnotexist\n\t\t}\n\t}\n}\n\nbaz.abc.ghi : randomunquotedString\n}"
 
         //Can replace settings in nested maps
         // Paths with quotes in the name are treated as a single Path, rather than multiple sub-paths


### PR DESCRIPTION
Previously, there was a bug wherein building out a config starting
from an empty ConfigDocument would cause the entire config to
exist on a single line. Fix this bug by modifying the addition
of new maps along a path to add multi-line maps instead of
single-line maps if the object is an empty root or if the
object being added to is a multi-line map.