### PR TITLE
Fix index out of bounds error

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeObject.java
@@ -170,7 +170,7 @@ final class ConfigNodeObject extends ConfigNodeComplexValue {
 
         // If the value we're inserting is a complex value, we'll need to indent it for insertion
         AbstractConfigNodeValue indentedValue;
-        if (value instanceof ConfigNodeComplexValue) {
+        if (value instanceof ConfigNodeComplexValue && !indentation.isEmpty()) {
             indentedValue = ((ConfigNodeComplexValue) value).indentText(indentation.get(indentation.size() - 1));
         } else {
             indentedValue = value;

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -436,6 +436,13 @@ class ConfigDocumentTest extends TestUtils {
         val configDocument = ConfigDocumentFactory.parseString(origText)
 
         assertEquals("a : 1", configDocument.withValueText("a", "1").render)
+
+        val mapVal = ConfigValueFactory.fromAnyRef(Map("a" -> 1, "b" -> 2).asJava)
+        assertEquals("a : {\n    # hardcoded value\n    \"a\" : 1,\n    # hardcoded value\n    \"b\" : 2\n}",
+            configDocument.withValue("a", mapVal).render)
+
+        val arrayVal = ConfigValueFactory.fromAnyRef(List(1, 2).asJava)
+        assertEquals("a : [\n    # hardcoded value\n    1,\n    # hardcoded value\n    2\n]", configDocument.withValue("a", arrayVal).render)
     }
 
     @Test


### PR DESCRIPTION
Fix an array index out of bounds error, which would occur if
a complex value was inserted into an empty root in a
ConfigDocument.

It looks like this bug was introduced by my last PR, so I've added some tests to ensure it's not happening anymore.