### PR TITLE
Removes usage of Character.isISOControl in favor of ConfigImplUtil.isC0Control

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
@@ -32,6 +32,14 @@ final public class ConfigImplUtil {
             return a.equals(b);
     }
 
+    public static boolean isC0Control(final char ch) {
+      return isC0Control((int)ch);
+    }
+
+    public static boolean isC0Control(int codepoint) {
+      return (codepoint >= 0x0000 && codepoint <= 0x001F);
+    }
+
     public static String renderJsonString(String s) {
         StringBuilder sb = new StringBuilder();
         sb.append('"');
@@ -60,7 +68,7 @@ final public class ConfigImplUtil {
                 sb.append("\\t");
                 break;
             default:
-                if (Character.isISOControl(c))
+                if (isC0Control(c))
                     sb.append(String.format("\\u%04x", (int) c));
                 else
                     sb.append(c);

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
@@ -32,11 +32,7 @@ final public class ConfigImplUtil {
             return a.equals(b);
     }
 
-    public static boolean isC0Control(final char ch) {
-      return isC0Control((int)ch);
-    }
-
-    public static boolean isC0Control(int codepoint) {
+    static boolean isC0Control(int codepoint) {
       return (codepoint >= 0x0000 && codepoint <= 0x001F);
     }
 

--- a/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokenizer.java
@@ -38,7 +38,7 @@ final class Tokenizer {
             return "tab";
         else if (codepoint == -1)
             return "end of file";
-        else if (Character.isISOControl(codepoint))
+        else if (ConfigImplUtil.isC0Control(codepoint))
             return String.format("control character 0x%x", codepoint);
         else
             return String.format("%c", codepoint);
@@ -498,7 +498,7 @@ final class Tokenizer {
                 } else if (c == '"') {
                     sbOrig.appendCodePoint(c);
                     break;
-                } else if (Character.isISOControl(c)) {
+                } else if (ConfigImplUtil.isC0Control(c)) {
                     throw problem(asString(c), "JSON does not allow unescaped " + asString(c)
                             + " in quoted strings, use a backslash escape");
                 } else {


### PR DESCRIPTION
Character.isISOControl returns true for C0 and C1 control characters.
Only C0 characters need to be escaped in valid JSON. This change adds a
utility method to detect C0 control characters and uses that in favor of
Character.isISOControl.