### PR TITLE
Stop rendering origin comments in config documents

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
@@ -1,9 +1,7 @@
 package com.typesafe.config.impl;
 
+import com.typesafe.config.*;
 import com.typesafe.config.parser.ConfigDocument;
-import com.typesafe.config.ConfigParseOptions;
-import com.typesafe.config.ConfigValue;
-import com.typesafe.config.ConfigException;
 
 import java.io.StringReader;
 import java.util.Iterator;
@@ -34,7 +32,9 @@ final class SimpleConfigDocument implements ConfigDocument {
     public ConfigDocument withValue(String path, ConfigValue newValue) {
         if (newValue == null)
             throw new ConfigException.BugOrBroken("null value for " + path + " passed to withValue");
-        return withValueText(path, newValue.render().trim());
+        ConfigRenderOptions options = ConfigRenderOptions.defaults();
+        options = options.setOriginComments(false);
+        return withValueText(path, newValue.render(options).trim());
     }
 
     @Override

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -438,11 +438,11 @@ class ConfigDocumentTest extends TestUtils {
         assertEquals("a : 1", configDocument.withValueText("a", "1").render)
 
         val mapVal = ConfigValueFactory.fromAnyRef(Map("a" -> 1, "b" -> 2).asJava)
-        assertEquals("a : {\n    # hardcoded value\n    \"a\" : 1,\n    # hardcoded value\n    \"b\" : 2\n}",
+        assertEquals("a : {\n    \"a\" : 1,\n    \"b\" : 2\n}",
             configDocument.withValue("a", mapVal).render)
 
         val arrayVal = ConfigValueFactory.fromAnyRef(List(1, 2).asJava)
-        assertEquals("a : [\n    # hardcoded value\n    1,\n    # hardcoded value\n    2\n]", configDocument.withValue("a", arrayVal).render)
+        assertEquals("a : [\n    1,\n    2\n]", configDocument.withValue("a", arrayVal).render)
     }
 
     @Test
@@ -452,7 +452,7 @@ class ConfigDocumentTest extends TestUtils {
 
         val configVal = ConfigValueFactory.fromAnyRef(Map("a" -> 1, "b" -> 2).asJava)
 
-        assertEquals("{ a : {\n     # hardcoded value\n     \"a\" : 1,\n     # hardcoded value\n     \"b\" : 2\n } }",
+        assertEquals("{ a : {\n     \"a\" : 1,\n     \"b\" : 2\n } }",
             configDocument.withValue("a", configVal).render)
     }
 }


### PR DESCRIPTION
Previously, when setting a ConfigValue in a ConfigDocument, origin
comments would be rendered, which would cause many values to have
lots of comments stating "# hardcoded value". Remove the rendering
of origin comments when inserting a ConfigValue into a
ConfigDocument.