### PR TITLE
add link to tscfg java wrapper (yes, java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,10 @@ format.
 #### Guice integration
   * Typesafe Config Guice https://github.com/racc/typesafeconfig-guice
 
+#### Java (yep!) wrappers for the Java library
+
+  * tscfg https://github.com/carueda/tscfg
+
 #### Scala wrappers for the Java library
 
   * Ficus https://github.com/ceedubs/ficus


### PR DESCRIPTION
tscfg is a command line tool (written in Scala) that takes a configuration specification parseable by Typesafe Config and generates all the Java boiler-plate to make the definitions available in type safe POJOs.

Current v0.1.4 is already pretty usable but can be improved in several ways.