### PR TITLE
Issue 380 - Empty string as a valid value for empty list

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/DefaultTransformer.java
+++ b/config/src/main/java/com/typesafe/config/impl/DefaultTransformer.java
@@ -48,7 +48,12 @@ final class DefaultTransformer {
                 }
                 break;
             case LIST:
-                // can't go STRING to LIST automatically
+                // can't go STRING to LIST automatically unless the string is empty
+                if (s.equals("")) {
+                    // Convert empty string to empty list
+                    ArrayList<AbstractConfigValue> emptyList = new ArrayList<AbstractConfigValue>();
+                    return new SimpleConfigList(value.origin(), emptyList);
+                }
                 break;
             case OBJECT:
                 // can't go STRING to OBJECT automatically

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
@@ -838,7 +838,8 @@ final class SimpleConfig implements Config, MergeableValue, Serializable {
             }
         } else if (referenceType == ConfigValueType.LIST) {
             // objects may be convertible to lists if they have numeric keys
-            if (value instanceof SimpleConfigList || value instanceof SimpleConfigObject) {
+            // empty strings may also be converted to lists
+            if (value instanceof SimpleConfigList || value instanceof SimpleConfigObject || value instanceof ConfigString) {
                 return true;
             } else {
                 return false;

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java
@@ -838,7 +838,7 @@ final class SimpleConfig implements Config, MergeableValue, Serializable {
             }
         } else if (referenceType == ConfigValueType.LIST) {
             // objects may be convertible to lists if they have numeric keys
-            // empty strings may also be converted to lists
+            // strings may also be convertible to lists if empty
             if (value instanceof SimpleConfigList || value instanceof SimpleConfigObject || value instanceof ConfigString) {
                 return true;
             } else {

--- a/config/src/test/java/beanconfig/ArraysConfig.java
+++ b/config/src/test/java/beanconfig/ArraysConfig.java
@@ -11,6 +11,7 @@ import com.typesafe.config.ConfigValue;
 public class ArraysConfig {
 
     List<Integer> empty;
+    List<Integer> fromEmptyString;
     List<Integer> ofInt;
     List<String> ofString;
     List<Double> ofDouble;
@@ -32,6 +33,10 @@ public class ArraysConfig {
     public void setEmpty(List<Integer> empty) {
         this.empty = empty;
     }
+
+    public List<Integer> getFromEmptyString() { return fromEmptyString; }
+
+    public void setFromEmptyString(List<Integer> fromEmptyString) { this.fromEmptyString = fromEmptyString; }
 
     public List<Integer> getOfInt() {
         return ofInt;

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -40,6 +40,7 @@
 
     "arrays" : {
         "empty" : [],
+        "fromEmptyString": "",
         "ofInt" : [1, 2, 3],
         "ofString" : [ ${strings.a}, ${strings.b}, ${strings.c} ],
         "of-double" : [3.14, 4.14, 5.14],

--- a/config/src/test/resources/test01.conf
+++ b/config/src/test/resources/test01.conf
@@ -26,7 +26,8 @@
         "true" : "true",
         "yes" : "yes",
         "false" : "false",
-        "no" : "no"
+        "no" : "no",
+        "empty": ""
     },
 
     "arrays" : {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -48,8 +48,7 @@ class ConfigBeanFactoryTest extends TestUtils {
 
         val expecteds = Seq(Missing("propNotListedInConfig", 77, "string"),
             WrongType("shouldBeInt", 78, "number", "boolean"),
-            WrongType("should-be-boolean", 79, "boolean", "number"),
-            WrongType("should-be-list", 80, "list", "string"))
+            WrongType("should-be-boolean", 79, "boolean", "number"))
 
         checkValidationException(e, expecteds)
     }
@@ -90,6 +89,7 @@ class ConfigBeanFactoryTest extends TestUtils {
         val beanConfig: ArraysConfig = ConfigBeanFactory.create(loadConfig().getConfig("arrays"), classOf[ArraysConfig])
         assertNotNull(beanConfig)
         assertEquals(List().asJava, beanConfig.getEmpty)
+        assertEquals(List().asJava, beanConfig.getFromEmptyString)
         assertEquals(List(1, 2, 3).asJava, beanConfig.getOfInt)
         assertEquals(List(32L, 42L, 52L).asJava, beanConfig.getOfLong)
         assertEquals(List("a", "b", "c").asJava, beanConfig.getOfString)

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -46,9 +46,9 @@ class ConfigBeanFactoryTest extends TestUtils {
             ConfigBeanFactory.create(config, classOf[ValidationBeanConfig])
         }
 
-        val expecteds = Seq(Missing("propNotListedInConfig", 77, "string"),
-            WrongType("shouldBeInt", 78, "number", "boolean"),
-            WrongType("should-be-boolean", 79, "boolean", "number"))
+        val expecteds = Seq(Missing("propNotListedInConfig", 78, "string"),
+            WrongType("shouldBeInt", 79, "number", "boolean"),
+            WrongType("should-be-boolean", 80, "boolean", "number"))
 
         checkValidationException(e, expecteds)
     }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -588,6 +588,18 @@ class ConfigTest extends TestUtils {
         assertEquals(Seq(), conf.getBooleanList("arrays.empty").asScala)
         assertEquals(Seq(), conf.getNumberList("arrays.empty").asScala)
         assertEquals(Seq(), conf.getList("arrays.empty").asScala)
+        
+        // get empty array from empty string as any type of array
+        assertEquals(Seq(), conf.getAnyRefList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getIntList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getLongList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getStringList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getLongList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getDoubleList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getObjectList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getBooleanList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getNumberList("strings.empty").asScala)
+        assertEquals(Seq(), conf.getList("strings.empty").asScala)
 
         // get typed arrays
         assertEquals(Seq(1, 2, 3), conf.getIntList("arrays.ofInt").asScala)

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -674,6 +674,10 @@ class ConfigTest extends TestUtils {
         }
 
         intercept[ConfigException.WrongType] {
+            conf.getList("strings.abcd")
+        }
+
+        intercept[ConfigException.WrongType] {
             conf.getMilliseconds("ints")
         }
 


### PR DESCRIPTION
As stated in #380 by @michellemay (colleague of mine), it is currently impossible to override a config value with an empty list using standard command line arguments (e.g. `-Dfoo=`).

This pull request attempts to solve the problem by allowing empty strings as valid values for lists and by converting them to empty lists.

This means `foo=""` would become valid for all `getList` methods and all would return an empty list of appropriate type.
It would also be possible to override a config value with an empty list using command line arguments like so: `-Dfoo=` .
