### PR TITLE
Update SBT and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.typesafe.sbt.SbtPgp.PgpKeys.{ useGpg, publishSigned, publishLocalSigned }
-
 // to release, bump major/minor/micro as appropriate,
 // update NEWS, update version in README.md, tag, then
 // publishSigned.
@@ -15,10 +13,10 @@ scalacOptions in GlobalScope in Test := Seq("-unchecked", "-deprecation", "-feat
 
 scalaVersion in ThisBuild := "2.10.4"
 
-useGpg in GlobalScope := true
+useGpg := true
 
-aggregate in publishSigned := false
-publishSigned := (publishSigned in configLib).value
+aggregate in PgpKeys.publishSigned := false
+PgpKeys.publishSigned := (PgpKeys.publishSigned in configLib).value
 
-aggregate in publishLocalSigned := false
-publishLocalSigned := (publishLocalSigned in configLib).value
+aggregate in PgpKeys.publishLocalSigned := false
+PgpKeys.publishLocalSigned := (PgpKeys.publishLocalSigned in configLib).value

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import com.typesafe.sbt.SbtGit
 import com.typesafe.sbt.SbtPgp.PgpKeys.{ useGpg, publishSigned, publishLocalSigned }
 
 // to release, bump major/minor/micro as appropriate,
@@ -6,8 +5,8 @@ import com.typesafe.sbt.SbtPgp.PgpKeys.{ useGpg, publishSigned, publishLocalSign
 // publishSigned.
 // Release tags should follow: http://semver.org/
 
-SbtGit.versionWithGit
-SbtGit.git.baseVersion := "1.3.0"
+enablePlugins(GitVersioning)
+git.baseVersion := "1.3.0"
 
 organization in GlobalScope := "com.typesafe"
 

--- a/config/build.sbt
+++ b/config/build.sbt
@@ -4,7 +4,6 @@ import de.johoop.jacoco4sbt.JacocoPlugin.jacoco
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
-import com.etsy.sbt.Checkstyle._
 
 SbtScalariform.scalariformSettings
 
@@ -26,14 +25,12 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
 externalResolvers += "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/"
 
-checkstyleSettings
+checkstyleConfigLocation := CheckstyleConfigLocation.File((baseDirectory.value / "checkstyle-config.xml").toString)
 
-CheckstyleTasks.checkstyleConfig := baseDirectory.value / "checkstyle-config.xml"
-
-CheckstyleTasks.checkstyle in Compile := {
+checkstyle in Compile := {
   val log = streams.value.log
-  (CheckstyleTasks.checkstyle in Compile).value
-  val resultFile = (target in Compile).value / "checkstyle-report.xml"
+  (checkstyle in Compile).value
+  val resultFile = (checkstyleOutputFile in Compile).value
   val results = scala.xml.XML.loadFile(resultFile)
   val errorFiles = results \\ "checkstyle" \\ "file"
 
@@ -61,10 +58,7 @@ CheckstyleTasks.checkstyle in Compile := {
 }
 
 // add checkstyle as a dependency of doc
-doc in Compile := {
-  (CheckstyleTasks.checkstyle in Compile).value
-  (doc in Compile).value
-}
+doc in Compile <<= (doc in Compile).dependsOn(checkstyle in Compile)
 
 findbugsSettings
 findbugsReportType := Some(ReportType.Html)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,7 @@
 import sbt._
 import Keys._
-import com.typesafe.sbt.osgi.SbtOsgi.{ OsgiKeys, osgiSettings }
+import com.typesafe.sbt.osgi.SbtOsgi
+import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
 
 object ConfigBuild extends Build {
@@ -49,11 +50,9 @@ object ConfigBuild extends Build {
                                    osgiSettings ++
                                    Seq(
                                      OsgiKeys.exportPackage := Seq("com.typesafe.config", "com.typesafe.config.impl"),
-                                     packagedArtifact in (Compile, packageBin) <<= (artifact in (Compile, packageBin), OsgiKeys.bundle).identityMap,
-                                     artifact in (Compile, packageBin) ~= { _.copy(`type` = "bundle") },
                                      publish := sys.error("use publishSigned instead of plain publish"),
                                      publishLocal := sys.error("use publishLocalSigned instead of plain publishLocal")
-                                   )) dependsOn testLib % "test->test"
+                                   )).enablePlugins(SbtOsgi) dependsOn testLib % "test->test"
 
     def project(id: String, base: File) = Project(id, base, settings = commonSettings)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,6 @@
 import sbt._
 import Keys._
+import com.etsy.sbt.checkstyle.CheckstylePlugin.autoImport._
 import com.typesafe.sbt.osgi.SbtOsgi
 import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
@@ -35,7 +36,9 @@ object ConfigBuild extends Build {
       Seq(aggregate in doc := false,
           doc := (doc in (configLib, Compile)).value,
           aggregate in packageDoc := false,
-          packageDoc := (packageDoc in (configLib, Compile)).value)
+          packageDoc := (packageDoc in (configLib, Compile)).value,
+          aggregate in checkstyle := false,
+          checkstyle := (checkstyle in (configLib, Compile)).value)
 
     lazy val root = Project(id = "root",
                             base = file("."),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "0.4.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "0.4.1")
 
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "0.4.1")
+addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")


### PR DESCRIPTION
Update SBT and plugins to latest versions except sbt-scalariform.

- sbt 0.13.7 -> 0.13.11
- sbt-git 0.6.2 -> 0.8.5
  - No longer need `jgit-repo` resolver
- sbt-pgp 0.8.1 -> 1.0.0
  - `useGpg` is synonym for `PgpKeys.useGpg in Global`
- sbt-osgi 0.6.0 -> 0.8.0
  - Settings for `packagedArtifact` and `artifact` are included in `osgiSettings`
- sbt-checkstyle-plugin 0.4.1 -> 3.0.0
  - Better task dependency: `doc` runs if `checkstyle` finished successfully.

Latest version of sbt-scalariform breaks existing code style (See https://github.com/kxbmap/config/commit/a89db1f52d5dcbf011682489e9dbe8573bf4f888).
So this PR does not contain sbt-scalariform update.
Next version of scalarifrom will solve this problem: https://github.com/scala-ide/scalariform/issues/202