### PR TITLE
Fix test failure on Windows

### DIFF
--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -5,15 +5,12 @@ package com.typesafe.config.impl
 
 import org.junit.Assert._
 import org.junit._
-import java.io.Reader
 import java.io.StringReader
 import com.typesafe.config._
-import java.util.HashMap
 import scala.collection.JavaConverters._
 import java.io.File
 import java.net.URL
 import java.util.Properties
-import java.io.ByteArrayInputStream
 
 class ConfParserTest extends TestUtils {
 
@@ -714,7 +711,7 @@ class ConfParserTest extends TestUtils {
     def includeFileNotQuoted() {
         // this test cannot work on Windows
         val f = resourceFile("test01")
-        if (f.toString.contains("\\")) {
+        if (isWindows) {
             System.err.println("includeFileNotQuoted test skipped on Windows")
         } else {
             val e = intercept[ConfigException.Parse] {
@@ -727,7 +724,7 @@ class ConfParserTest extends TestUtils {
     @Test
     def includeFileNotQuotedAndSpecialChar() {
         val f = resourceFile("test01")
-        if (f.toString.contains("\\")) {
+        if (isWindows) {
             System.err.println("includeFileNotQuoted test skipped on Windows")
         } else {
             val e = intercept[ConfigException.Parse] {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -13,7 +13,6 @@ import com.typesafe.config.ConfigObject
 import com.typesafe.config.ConfigList
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigValueType
-import com.typesafe.config.ConfigOrigin
 import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValueFactory
 import com.typesafe.config.ConfigFactory
@@ -721,7 +720,9 @@ class ConfigValueTest extends TestUtils {
         // the filename is made absolute when converting to url
         assertTrue(hasFilename.url.toExternalForm.contains("foo"))
         assertNull(noFilename.url)
-        assertEquals("file:/baz", SimpleConfigOrigin.newFile("/baz").url.toExternalForm)
+        val rootFile = SimpleConfigOrigin.newFile("/baz")
+        val rootFileURL = if (isWindows) s"file:/$userDrive/baz" else "file:/baz"
+        assertEquals(rootFileURL, rootFile.url.toExternalForm)
 
         val urlOrigin = SimpleConfigOrigin.newURL(new URL("file:/foo"))
         assertEquals("/foo", urlOrigin.filename)

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -4,12 +4,10 @@
 package com.typesafe.config.impl
 
 import org.junit.Assert._
-import org.junit._
 import com.typesafe.config.ConfigOrigin
 import java.io.Reader
 import java.io.StringReader
 import com.typesafe.config.ConfigParseOptions
-import com.typesafe.config.Config
 import com.typesafe.config.ConfigSyntax
 import com.typesafe.config.ConfigFactory
 import java.io.File
@@ -20,6 +18,7 @@ import java.io.ObjectInputStream
 import java.io.NotSerializableException
 import scala.annotation.tailrec
 import java.net.URL
+import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.Callable
 import com.typesafe.config._
@@ -711,6 +710,9 @@ abstract trait TestUtils {
     def nodeKeySubstitution(s: String) = new ConfigNodeSimpleValue(tokenKeySubstitution(s))
     def nodeOptionalSubstitution(expression: Token*) = new ConfigNodeSimpleValue(tokenOptionalSubstitution(expression: _*))
     def nodeSubstitution(expression: Token*) = new ConfigNodeSimpleValue(tokenSubstitution(expression: _*))
+
+    def isWindows: Boolean = sys.props.get("os.name").exists(_.toLowerCase(Locale.ROOT).contains("windows"))
+    def userDrive: String = if (isWindows) sys.props.get("user.dir").fold("")(_.takeWhile(_ != File.separatorChar)) else ""
 
     // this is importantly NOT using Path.newPath, which relies on
     // the parser; in the test suite we are often testing the parser,


### PR DESCRIPTION
File `/foo` means like `C:\foo` (`C:` is drive that contains the current working directory) on Windows.
