### PR TITLE
add SHocon implementation to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ to merge it in.
   - [Debugging Your Configuration](#debugging-your-configuration)
   - [Supports Java 8 and Later](#supports-java-8-and-later)
   - [Rationale for Supported File Formats](#rationale-for-supported-file-formats)
-  - [Other APIs (Wrappers and Ports)](#other-apis-wrappers-and-ports)
+  - [Other APIs (Wrappers, Ports and Utilities)](#other-apis-wrappers-ports-and-utilities)
+    - [Guice integration](#guice-integration)
+    - [Java (yep!) wrappers for the Java library](#java-yep-wrappers-for-the-java-library)
     - [Scala wrappers for the Java library](#scala-wrappers-for-the-java-library)
     - [Clojure wrappers for the Java library](#clojure-wrappers-for-the-java-library)
+    - [Scala port](#scala-port)
     - [Ruby port](#ruby-port)
     - [Puppet module](#puppet-module)
     - [Python port](#python-port)
-    - [C++ port](#c++-port)
-
+    - [C++ port](#c-port)
+    - [Linting tool](#linting-tool)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -842,6 +845,10 @@ format.
 
   * beamly-core.config https://github.com/beamly/beamly-core.config
 
+#### Scala port
+
+  * SHocon https://github.com/unicredit/shocon (work with both Scala and Scala.Js)
+
 #### Ruby port
 
    * https://github.com/puppetlabs/ruby-hocon
@@ -859,5 +866,5 @@ format.
    * https://github.com/puppetlabs/cpp-hocon
 
 #### Linting tool
-   
-   * A web based linting tool http://www.hoconlint.com/ 
+
+   * A web based linting tool http://www.hoconlint.com/


### PR DESCRIPTION
Added reference to pure Scala Port of Hocon.
This is useful especially for Scala.Js projects.