### PR TITLE
Command line for alternative config `-Dconfig.file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ library examples in `examples/` show how to accept a custom config
 while defaulting to `ConfigFactory.load()`.
 
 For applications using `application.{conf,json,properties}`,
-system properties can be used to force a different config source:
+system properties can be used to force a different config source
+(e.g. from command line `-Dconfig.file=path/to/config-file`):
 
  - `config.resource` specifies a resource name - not a
    basename, i.e. `application.conf` not `application`


### PR DESCRIPTION
Each time I search this information, I search `-D` in this README but can't find it **quickly**, so need to google it, then go to stackoverflow, etc.

With this little example this information quickly reachable.