### PR TITLE
ConfigFactory.invalidateCaches() also resets environment variables cache

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -496,6 +496,7 @@ public final class ConfigFactory {
         // We rely on this having the side effect that it drops
         // all caches
         ConfigImpl.reloadSystemPropertiesConfig();
+        ConfigImpl.reloadEnvVariablesConfig();
     }
 
     /**

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -339,7 +339,7 @@ public class ConfigImpl {
     }
 
     private static class EnvVariablesHolder {
-        static final AbstractConfigObject envVariables = loadEnvVariables();
+        static volatile AbstractConfigObject envVariables = loadEnvVariables();
     }
 
     static AbstractConfigObject envVariablesAsConfigObject() {
@@ -352,6 +352,12 @@ public class ConfigImpl {
 
     public static Config envVariablesAsConfig() {
         return envVariablesAsConfigObject().toConfig();
+    }
+
+    public static void reloadEnvVariablesConfig() {
+        // ConfigFactory.invalidateCaches() relies on this having the side
+        // effect that it drops all caches
+        EnvVariablesHolder.envVariables = loadEnvVariables();
     }
 
     public static Config defaultReference(final ClassLoader loader) {


### PR DESCRIPTION
While in production you are unlikely to modify environment variables on the fly (it's very difficult to do so), it's helpful to be able to do so in testing to ensure that you've configured your application correctly and it responds appropriately to environment variable change.