### PR TITLE
add carueda/cfg Scala wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ format.
   * static-config https://github.com/Krever/static-config
   * validated-config https://github.com/carlpulley/validated-config
   * Cedi Config https://github.com/ccadllc/cedi-config
+  * Cfg https://github.com/carueda/cfg
 
 #### Clojure wrappers for the Java library
 


### PR DESCRIPTION
Cfg is an annotation implemented in Scalameta for both configuration specification and access in a type safe manner and free of boilerplate.

(http://www.typesafe.com/contribute/cla already signed from a previous merged PR)