### PR TITLE
Add fallback ConfigReferenceResolver

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigResolver.java
+++ b/config/src/main/java/com/typesafe/config/ConfigResolver.java
@@ -1,0 +1,38 @@
+package com.typesafe.config;
+
+/**
+ * Implement this interface and provide an instance to
+ * {@link ConfigResolveOptions#appendResolver ConfigResolveOptions.appendResolver()}
+ * to provide custom behavior when unresolved substitutions are encountered
+ * during resolution.
+ * @since 1.3.2
+ */
+public interface ConfigResolver {
+
+    /**
+     * Returns the value to substitute for the given unresolved path. To get the
+     * components of the path use {@link ConfigUtil#splitPath(String)}. If a
+     * non-null value is returned that value will be substituted, otherwise
+     * resolution will continue to consider the substitution as still
+     * unresolved.
+     *
+     * @param path the unresolved path
+     * @return the value to use as a substitution or null
+     */
+    public ConfigValue lookup(String path);
+
+    /**
+     * Returns a new resolver that falls back to the given resolver if this
+     * one doesn't provide a substitution itself.
+     *
+     * It's important to handle the case where you already have the fallback
+     * with a "return this", i.e. this method should not create a new object if
+     * the fallback is the same one you already have. The same fallback may be
+     * added repeatedly.
+     *
+     * @param fallback the previous includer for chaining
+     * @return a new resolver
+     */
+    public ConfigResolver withFallback(ConfigResolver fallback);
+
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigRenderOptions;
+import com.typesafe.config.ConfigResolveOptions;
+import com.typesafe.config.ConfigValue;
 import com.typesafe.config.ConfigValueType;
 
 /**
@@ -88,7 +90,8 @@ final class ConfigReference extends AbstractConfigValue implements Unmergeable {
                 v = result.value;
                 newContext = result.context;
             } else {
-                v = null;
+                ConfigValue fallback = context.options().getResolver().lookup(expr.path().render());
+                v = (AbstractConfigValue) fallback;
             }
         } catch (NotPossibleToResolve e) {
             if (ConfigImpl.traceSubstitutionsEnabled())


### PR DESCRIPTION
Here is a suggestion for how to support fallback reference resolution. I'm interested in whether you would suggest any major changes -- like, is the options the right place to hold the resolver and does it make sense to create the path interface.