### PR TITLE
Fix spelling

### DIFF
--- a/HOCON.md
+++ b/HOCON.md
@@ -1614,7 +1614,7 @@ So if you know that you HOCON needs "PATH" then you must ensure that
 the variable is defined as "PATH" rather than some other name such as
 "Path" or "path".
 However, Windows does not allow us to change the case of an existing env var; we can't
-simply redefine the var with an upper case name.
+simply redefine the var with an uppercase name.
 The only way to ensure that your environment variables have the desired case
 is to first undefine all the env vars that you will depend on then redefine
 them with the required case.

--- a/HOCON.md
+++ b/HOCON.md
@@ -840,7 +840,7 @@ because the self reference has to "look back" to an undefined `a`:
 
     a = ${?a}foo
 
-In general, in resolving a substitution the implementation must:
+In general, in resolving a substitution, the implementation must:
 
  - lazy-evaluate the substitution target so there's no
    "circularity by side effect"

--- a/HOCON.md
+++ b/HOCON.md
@@ -388,7 +388,7 @@ For purposes of concatenation, "array" also means "substitution
 that resolves to an array" and "object" also means "substitution
 that resolves to an object."
 
-Within an field value or array element, if only non-newline
+Within a field value or array element, if only non-newline
 whitespace separates the end of a first array or object or
 substitution from the start of a second array or object or
 substitution, the two values are concatenated. Newlines may occur

--- a/HOCON.md
+++ b/HOCON.md
@@ -1608,7 +1608,7 @@ is straightforward; ie just make sure you define all your vars with the required
 Windows is more confusing. Windows environment variables names may contain a
 mix of upper and lowercase characters, eg "Path", however Windows does not
 allow one to define multiple instances of the same name but differing in case.
-Whilst accessing env vars in Windows is case insensitive, accessing env vars in
+Whilst accessing env vars in Windows is case-insensitive, accessing env vars in
 HOCON is case sensitive.
 So if you know that you HOCON needs "PATH" then you must ensure that
 the variable is defined as "PATH" rather than some other name such as

--- a/HOCON.md
+++ b/HOCON.md
@@ -1619,7 +1619,7 @@ The only way to ensure that your environment variables have the desired case
 is to first undefine all the env vars that you will depend on then redefine
 them with the required case.
 
-For example, the the ambient environment might have this definition ...
+For example, the ambient environment might have this definition ...
 
 ```
 set Path=A;B;C

--- a/HOCON.md
+++ b/HOCON.md
@@ -1301,7 +1301,7 @@ This can use the general "units format" described above; bare
 numbers are taken to be in milliseconds already, while strings are
 parsed as a number plus an optional unit string.
 
-The supported unit strings for duration are case sensitive and
+The supported unit strings for duration are case-sensitive and
 must be lowercase. Exactly these strings are supported:
 
  - `ns`, `nano`, `nanos`, `nanosecond`, `nanoseconds`
@@ -1321,7 +1321,7 @@ This can use the general "units format" described above; bare
 numbers are taken to be in days, while strings are
 parsed as a number plus an optional unit string.
 
-The supported unit strings for period are case sensitive and
+The supported unit strings for period are case-sensitive and
 must be lowercase. Exactly these strings are supported:
 
  - `d`, `day`, `days`
@@ -1542,7 +1542,7 @@ It's recommended that HOCON keys always use lowercase, because
 environment variables generally are capitalized. This avoids
 naming collisions between environment variables and configuration
 properties. (While on Windows getenv() is generally not
-case-sensitive, the lookup will be case sensitive all the way
+case-sensitive, the lookup will be case-sensitive all the way
 until the env variable fallback lookup is reached).
 
 See also the notes below on Windows and case sensitivity.
@@ -1597,7 +1597,7 @@ Differences include but are probably not limited to:
 
 ## Note on Windows and case sensitivity of environment variables
 
-HOCON's lookup of environment variable values is always case sensitive, but
+HOCON's lookup of environment variable values is always case-sensitive, but
 Linux and Windows differ in their handling of case.
 
 Linux allows one to define multiple environment variables with the same
@@ -1609,7 +1609,7 @@ Windows is more confusing. Windows environment variables names may contain a
 mix of upper and lowercase characters, eg "Path", however Windows does not
 allow one to define multiple instances of the same name but differing in case.
 Whilst accessing env vars in Windows is case-insensitive, accessing env vars in
-HOCON is case sensitive.
+HOCON is case-sensitive.
 So if you know that you HOCON needs "PATH" then you must ensure that
 the variable is defined as "PATH" rather than some other name such as
 "Path" or "path".

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Report bugs to the GitHub issue tracker. Send patches as pull
 requests on GitHub.
 
 Before we can accept pull requests, you will need to agree to the
-Typesafe Contributor License Agreement online, using your GitHub
+Akka Contributor License Agreement online, using your GitHub
 account - it takes 30 seconds.  You can do this at
-https://www.lightbend.com/contribute/cla
+https://contribute.akka.io/contribute/cla
 
 Please see
 [CONTRIBUTING](https://github.com/lightbend/config/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ that use Java 8 types will need to be removed.
 The three file formats each have advantages.
 
  - Java `.properties`:
-   - Java standard, built in to JVM
+   - Java standard, built into JVM
    - Supported by many tools such as IDEs
  - JSON:
    - easy to generate programmatically

--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -1109,7 +1109,7 @@ public final class ConfigFactory {
 
     /**
      * Like {@link #parseApplicationReplacement()} but allows you to specify a class loader
-     * ti yse rather than the current context class loader.
+     * rather than using the current context class loader.
      *
      * @since 1.4.1
      *

--- a/config/src/main/java/com/typesafe/config/ConfigLoadingStrategy.java
+++ b/config/src/main/java/com/typesafe/config/ConfigLoadingStrategy.java
@@ -5,7 +5,7 @@ package com.typesafe.config;
  * calls {@link ConfigFactory#load}.
  *
  * Usually you don't have to implement this interface but it may be required
- * when you fixing a improperly implemented library with unavailable source code.
+ * when you fix an improperly implemented library with unavailable source code.
  *
  * You have to define VM property {@code config.strategy} to replace default strategy with your own.
  */

--- a/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigValueFactory.java
@@ -38,10 +38,10 @@ public final class ConfigValueFactory {
      * 
      * <p>
      * The originDescription will be used to set the origin() field on the
-     * ConfigValue. It should normally be the name of the file the values came
-     * from, or something short describing the value such as "default settings".
-     * The originDescription is prefixed to error messages so users can tell
-     * where problematic values are coming from.
+     * ConfigValue. It should normally be the name of the file from which the
+     * values came, or something short describing the value such as "default
+     * settings". The originDescription is prefixed to error messages so users
+     * can tell where problematic values are coming from.
      * 
      * <p>
      * Supplying the result of ConfigValue.unwrapped() to this function is

--- a/config/src/main/java/com/typesafe/config/Optional.java
+++ b/config/src/main/java/com/typesafe/config/Optional.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Allows an config property to be {@code null}.
+ * Allows a config property to be {@code null}.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/config/src/main/java/com/typesafe/config/impl/ConfigDelayedMergeObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigDelayedMergeObject.java
@@ -262,7 +262,7 @@ final class ConfigDelayedMergeObject extends AbstractConfigObject implements Unm
                 AbstractConfigValue v = objectLayer.attemptPeekWithPartialResolve(key);
                 if (v != null) {
                     if (v.ignoresFallbacks()) {
-                        // we know we won't need to merge anything in to this
+                        // we know we won't need to merge anything into this
                         // value
                         return v;
                     } else {

--- a/config/src/main/java/com/typesafe/config/impl/Tokens.java
+++ b/config/src/main/java/com/typesafe/config/impl/Tokens.java
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigValueType;
 
-/* FIXME the way the subclasses of Token are private with static isFoo and accessors is kind of ridiculous. */
+/* FIXME the way subclasses of Token are private with static isFoo and accessors is kind of ridiculous. */
 final class Tokens {
     static private class Value extends Token {
 

--- a/config/src/test/resources/test04.conf
+++ b/config/src/test/resources/test04.conf
@@ -279,7 +279,7 @@ akka {
       ensemble-size = 3
       quorum-size = 2
       snapshot-frequency = 1000                   # The number of messages that should be logged between every actor snapshot
-      timeout = 30                                # Timeout for asyncronous (write-behind) operations
+      timeout = 30                                # Timeout for asynchronous (write-behind) operations
     }
   }
 

--- a/config/src/test/resources/test04.conf
+++ b/config/src/test/resources/test04.conf
@@ -112,7 +112,7 @@ akka {
                                                                         #     available: "transaction-log" and "data-grid"
                                                                         #     default is "transaction-log"
 
-        #    strategy = "write-through"                                 # guaranteees for replication
+        #    strategy = "write-through"                                 # guarantees for replication
                                                                         #     available: "write-through" and "write-behind"
                                                                         #     default is "write-through"
 

--- a/config/src/test/resources/test04.conf
+++ b/config/src/test/resources/test04.conf
@@ -228,7 +228,7 @@ akka {
     secure-cookie = ""                            # Generate your own with '$AKKA_HOME/scripts/generate_config_with_secure_cookie.sh'
                                                   #     or using 'akka.util.Crypt.generateSecureCookie'
 
-    remote-daemon-ack-timeout = 30                # Timeout for ACK of cluster operations, lik checking actor out etc.
+    remote-daemon-ack-timeout = 30                # Timeout for ACK of cluster operations, like checking actor out etc.
 
     use-passive-connections = on                  # Reuse inbound connections for outbound messages
 

--- a/config/src/test/resources/test05.conf
+++ b/config/src/test/resources/test05.conf
@@ -135,7 +135,7 @@ mail.smtp=mock
 # Execution pool
 # ~~~~~
 # Default to 1 thread in DEV mode or nb processors + 1 threads in PROD mode.
-# Try to keep a low as possible. 1 thread will serialize all requests (very usefull for debugging purpose)
+# Try to keep a low as possible. 1 thread will serialize all requests (very useful for debugging purpose)
 # play.pool=3
 
 # Open file from errors pages

--- a/config/src/test/resources/test05.conf
+++ b/config/src/test/resources/test05.conf
@@ -46,7 +46,7 @@ module.secure=${?play.path}/modules/secure
 # If you need to change the HTTP port, uncomment this (default is set to 9000)
 # http.port=9000
 #
-# By default the server listen for HTTP on the wilcard address.
+# By default the server listen for HTTP on the wildcard address.
 # You can restrict this.
 # http.address=127.0.0.1
 

--- a/config/src/test/resources/test05.conf
+++ b/config/src/test/resources/test05.conf
@@ -16,7 +16,7 @@ application.mode=dev
 
 # Secret key
 # ~~~~~
-# The secret key is used to secure cryptographics functions
+# The secret key is used to secure cryptographic functions
 # If you deploy your application to several instances be sure to use the same key !
 application.secret=s1kwayg211q9v4387pvarbmyqnht7hrl54d34lsz0yh9btb117br293a25trz31o
 

--- a/config/src/test/resources/test05.conf
+++ b/config/src/test/resources/test05.conf
@@ -111,7 +111,7 @@ jpa.ddl=update
 
 # Memcached configuration
 # ~~~~~ 
-# Enable memcached if needed. Otherwise a local cache is used.
+# Enable memcached if needed. Otherwise, a local cache is used.
 # memcached=enabled
 #
 # Specify memcached host (default to 127.0.0.1:11211)

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -468,7 +468,7 @@ class ConfParserTest extends TestUtils {
                 """)
         assertComments(Seq(" AfterSepOwnLine"), conf10, "foo")
 
-        // comments comments everywhere
+        // comments, comments everywhere
         val conf11 = parseConfig("""
                 {# Before
                 foo

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -779,7 +779,7 @@ class ConfParserTest extends TestUtils {
         val missing = ConfigParseOptions.defaults().setAllowMissing(true)
 
         val ex = intercept[Exception] {
-            ConfigFactory.parseString("include required(classpath( \"nonexistant\") )", missing)
+            ConfigFactory.parseString("include required(classpath( \"nonexistent\") )", missing)
         }
 
         val actual = ex.getMessage

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
@@ -769,7 +769,7 @@ class ConfigSubstitutionTest extends TestUtils {
     }
 
     private val substEnvVarObject = {
-        // prefix the names of keys with "key_" to allow us to embed a case sensitive env var name
+        // prefix the names of keys with "key_" to allow us to embed a case-sensitive env var name
         // in the key that wont therefore risk a naming collision with env vars themselves
         parseObject("""
 {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
@@ -753,7 +753,7 @@ class ConfigSubstitutionTest extends TestUtils {
         assertEquals(List("0", "1"), resolved.getList("a").unwrapped().asScala)
     }
 
-    // this is a weird test, it used to test fallback to system props which made more sense.
+    // this is a weird test, it used to test falling back to system props which made more sense.
     // Now it just tests that if you override with system props, you can use system props
     // in substitutions.
     @Test

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -1335,7 +1335,7 @@ class ConfigTest extends TestUtils {
         val unresolved = ConfigFactory.parseString("a = ${foo}, b = ${bar}, c { x = ${m}, y = ${n}, z = foo${m}bar }, alwaysResolveable=${alwaysValue}, alwaysValue=42")
         assertFalse("config with substitutions starts as not resolved", unresolved.isResolved)
 
-        // resolve() by default throws with unresolveable substs
+        // resolve() by default throws with unresolveable substitutions
         intercept[ConfigException.UnresolvedSubstitution] {
             unresolved.resolve(ConfigResolveOptions.defaults())
         }

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -941,7 +941,7 @@ class PublicApiTest extends TestUtils {
         assertEquals("config.file is not set", null, System.getProperty("config.file"))
         val old = System.getProperty("config.resource")
         try {
-            System.setProperty("config.resource", "donotexists.conf")
+            System.setProperty("config.resource", "nonexistent.conf")
             intercept[ConfigException.IO] {
                 ConfigFactory.load()
             }
@@ -964,7 +964,7 @@ class PublicApiTest extends TestUtils {
         assertEquals("config.resource is not set", null, System.getProperty("config.resource"))
         val old = System.getProperty("config.file")
         try {
-            System.setProperty("config.file", "donotexists.conf")
+            System.setProperty("config.file", "nonexistent.conf")
             intercept[ConfigException.IO] {
                 ConfigFactory.load()
             }

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -638,7 +638,7 @@ class PublicApiTest extends TestUtils {
         System.setProperty("config.strategy", classOf[TestStrategy].getCanonicalName)
 
         try {
-            val incovationsBeforeTest = TestStrategy.getIncovations()
+            val invocationsBeforeTest = TestStrategy.getInvocations()
             val loaderA1 = new TestClassLoader(this.getClass().getClassLoader(),
                 Map("reference.conf" -> resourceFile("a_1.conf").toURI.toURL()))
 
@@ -647,7 +647,7 @@ class PublicApiTest extends TestUtils {
             }
             ConfigFactory.load()
             assertEquals(1, configA1.getInt("a"))
-            assertEquals(2, TestStrategy.getIncovations() - incovationsBeforeTest)
+            assertEquals(2, TestStrategy.getInvocations() - invocationsBeforeTest)
         } finally {
             System.clearProperty("config.strategy")
         }
@@ -1185,6 +1185,6 @@ class TestStrategy extends DefaultConfigLoadingStrategy {
 
 object TestStrategy {
     private var invocations = 0
-    def getIncovations() = invocations
+    def getInvocations() = invocations
     def increment() = invocations += 1
 }

--- a/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
@@ -30,10 +30,10 @@ class UtilTest extends TestUtils {
 
         val s = " \u00A0 \n  " + supplementaryChars + "  \n  \u00A0 "
         val asciiTrimmed = s.trim()
-        val unitrimmed = ConfigImplUtil.unicodeTrim(s)
+        val uniTrimmed = ConfigImplUtil.unicodeTrim(s)
 
-        assertFalse(asciiTrimmed.equals(unitrimmed))
-        assertEquals(supplementaryChars, unitrimmed)
+        assertFalse(asciiTrimmed.equals(uniTrimmed))
+        assertEquals(supplementaryChars, uniTrimmed)
     }
 
     @Test

--- a/examples/java/complex-app/src/main/java/ComplexApp.java
+++ b/examples/java/complex-app/src/main/java/ComplexApp.java
@@ -66,7 +66,7 @@ class ComplexApp {
 
         // Here's an illustration that simple-lib will get upset if we pass it
         // a bad config. In this case, we'll fail to merge the reference
-        // config in to complex-app.simple-lib-context, so simple-lib will
+        // config into complex-app.simple-lib-context, so simple-lib will
         // point out that some settings are missing.
         try {
             demoConfigInSimpleLib(config2.getConfig("complex-app.simple-lib-context"));

--- a/examples/scala/complex-app/src/main/scala/ComplexApp.scala
+++ b/examples/scala/complex-app/src/main/scala/ComplexApp.scala
@@ -59,7 +59,7 @@ object ComplexApp extends App {
 
     // Here's an illustration that simple-lib will get upset if we pass it
     // a bad config. In this case, we'll fail to merge the reference
-    // config in to complex-app.simple-lib-context, so simple-lib will
+    // config into complex-app.simple-lib-context, so simple-lib will
     // point out that some settings are missing.
     try {
         demoConfigInSimpleLib(config2.getConfig("complex-app.simple-lib-context"))


### PR DESCRIPTION
I have read [Maintained by](https://github.com/lightbend/config?tab=readme-ov-file#maintained-by)

I'm happy to split or drop things if people are interested.

Akka replaced Lightbend, so the CLA link redirects which means you should apply 5808a5deee1d1adea31de96a2a241b4778063ee6 or something very close to it.

The rest are more typical spelling / grammar fixes -- I started on this repository because we use it transitively and I generally send PR contributions to things I/we use. I'm not attached to the corrections, but I find it easier to work w/ code when it doesn't have typos.