### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
           - java: 11
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ca-certificates gnupg
           
+          # Retrieve the Scala SBT public key
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" |
+            sudo tee /usr/share/keyrings/scala-sbt.asc > /dev/null
+
           # Add the sbt repositories to apt sources
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
-          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-      
-          # Import the Scala SBT public key
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
-            | sudo apt-key add -
+          echo "deb [signed-by=/usr/share/keyrings/scala-sbt.asc] https://repo.scala-sbt.org/scalasbt/debian all main" |
+            sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb [signed-by=/usr/share/keyrings/scala-sbt.asc] https://repo.scala-sbt.org/scalasbt/debian /" |
+            sudo tee /etc/apt/sources.list.d/sbt_old.list
       
           # Now update and install
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
     if: github.repository == 'lightbend/config'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11


### PR DESCRIPTION
In any event, you're going to want to apply 18959b16c41b2fb47ab445183ff9795058d861fd or something like it as the workflows are using obsolete action versions which trigger warnings.

Hopefully, eventually, `apt-key` will disappear, and you'd want to apply fc4bf1388c9a4d43f8f88618f0834ee2f77cf179 or something like it.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References
- https://github.com/lightbend/config/pull/840#issuecomment-4249927939
