### PR TITLE
fix: make SimpleConfigObject.keySet() unmodifiable

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -606,7 +606,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
 
     @Override
     public Set<String> keySet() {
-        return value.keySet();
+        return Collections.unmodifiableSet(value.keySet());
     }
 
     @Override

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -491,6 +491,8 @@ class ConfigValueTest extends TestUtils {
         unsupported { m.put("hello", intValue(42)) }
         unsupported { m.putAll(Collections.emptyMap[String, AbstractConfigValue]()) }
         unsupported { m.remove("a") }
+        unsupported { m.keySet().remove("a") }
+        unsupported { m.keySet().clear() }
     }
 
     @Test


### PR DESCRIPTION
ConfigObject is documented as immutable, but `keySet()` returned the backing map's live key set, which allows element removal that mutates the object. Wrap it in `Collections.unmodifiableSet`. Closes #819.